### PR TITLE
make the version feature more useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,18 @@ Later on, ```argv``` can be retrived with ```yargs.argv```
 
 Add an option (e.g., `--version`) that displays the version number (given by the
 `version` parameter) and exits the process. If present, the `description`
-parameter customises the description of the version option in the usage string.
+parameter customizes the description of the version option in the usage string.
+
+You can provide a `function` for version, rather than a string.
+This is useful if you want to use the version from your package.json:
+
+```js
+var argv = require('yargs')
+  .version(function() {
+    return require('../package').version;
+  })
+  .argv;
+```
 
 .showHelpOnFail(enable, [message])
 ----------------------------------

--- a/index.js
+++ b/index.js
@@ -265,9 +265,9 @@ function Argv (processArgs, cwd) {
 
     var versionOpt = null;
     self.version = function (ver, opt, msg) {
-        versionOpt = opt;
+        versionOpt = opt || 'version';
         usage.version(ver);
-        self.describe(opt, msg || 'Show version number');
+        self.describe(versionOpt, msg || 'Show version number');
         return self;
     };
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -297,7 +297,8 @@ module.exports = function (yargs) {
     };
 
     self.showVersion = function() {
-        console.log(version);
+        if (typeof version === 'function') console.log(version());
+        else console.log(version);
     };
 
     return self;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/chevex/yargs.git"
+    "url": "http://github.com/bcoe/yargs.git"
   },
   "config": {
     "blanket": {

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,5 +1,6 @@
 {
     "herp": "derp",
     "z": 55,
-    "foo": "baz"
+    "foo": "baz",
+    "version": "1.0.2"
 }

--- a/test/usage.js
+++ b/test/usage.js
@@ -717,6 +717,30 @@ describe('usage tests', function () {
             r.should.have.property('exit').and.be.ok;
             r.logs[0].should.eql('1.0.1');
         });
+
+        it('should allow a function to be provided, rather than a number', function() {
+            var r = checkUsage(function () {
+                return yargs(['--version'])
+                    .version(function() {
+                      return require('./fixtures/config').version;
+                    }, 'version')
+                    .wrap(null)
+                    .argv;
+            });
+            r.logs[0].should.eql('1.0.2');
+        });
+
+        it("should default to 'version' as version option", function() {
+            var r = checkUsage(function () {
+                return yargs(['--version'])
+                    .version(function() {
+                      return require('./fixtures/config').version;
+                    })
+                    .wrap(null)
+                    .argv;
+            });
+            r.logs[0].should.eql('1.0.2');
+        });
     });
 
     describe('showHelpOnFail', function () {


### PR DESCRIPTION
`.version()` is cool, but you usually want to load the version # programmatically rather than having it hard-coded. This change allows you to optionally pass a function to `.version()`, which can be (as an example) used to load the version # from the package.json. 