### PR TITLE
uses function as default value resulted in a broken usage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ Set `argv[key]` to `value` if no option was specified on `process.argv`.
 
 Optionally `.default()` can take an object that maps keys to default values.
 
+But wait, there's more! the default value can be a `function` which returns
+a value. The name of the function will be used in the usage string:
+
+```js
+var argv = require('yargs')
+  .default('random', function randomValue() {
+    return Math.random() * 256;
+  }).argv;
+```
+
 .demand(key, [msg | boolean])
 -----------------------------
 .require(key, [msg | boolean])

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Optionally `.alias()` can take an object that maps keys to aliases.
 Each key of this object should be the canonical version of the option, and each
 value should be a string or an array of strings.
 
-.default(key, value)
+.default(key, value, [description])
 --------------------
 
 Set `argv[key]` to `value` if no option was specified on `process.argv`.
@@ -379,6 +379,13 @@ var argv = require('yargs')
   .default('random', function randomValue() {
     return Math.random() * 256;
   }).argv;
+```
+
+Optionally, `description` can also be provided and will take precedence over
+displaying the value in the usage instructions:
+
+```js
+.default('timeout', 60000, '(one-minute)');
 ```
 
 .demand(key, [msg | boolean])

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function Argv (processArgs, cwd) {
             string: [],
             alias: {},
             default: {},
+            defaultDescription: {},
             requiresArg: [],
             count: [],
             normalize: [],
@@ -94,13 +95,14 @@ function Argv (processArgs, cwd) {
         return self;
     };
 
-    self.default = function (key, value) {
+    self.default = function (key, value, defaultDescription) {
         if (typeof key === 'object') {
             Object.keys(key).forEach(function (k) {
                 self.default(k, key[k]);
             });
         }
         else {
+            options.defaultDescription[key] = defaultDescription;
             options.default[key] = value;
         }
         return self;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,8 @@
 // fancy-pants parsing of argv, originally forked
 // from minimist: https://www.npmjs.com/package/minimist
-var path = require('path');
-var fs = require('fs');
+var fs = require('fs'),
+  path = require('path'),
+  S = require('string');
 
 module.exports = function (args, opts) {
     if (!opts) opts = {};
@@ -33,9 +34,7 @@ module.exports = function (args, opts) {
     });
 
     function toCamelCase(str) {
-        return str.split('-').map(function(word, i) {
-            return (i ? word[0].toUpperCase() + word.slice(1) : word);
-        }).join('');
+        return S(str).camelize().s;
     }
 
     var aliases = {},

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -168,7 +168,7 @@ module.exports = function (yargs) {
                     ? '[required]'
                     : null
                 ,
-                defaultString(options.default[key])
+                defaultString(options.default[key], options.defaultDescription[key])
             ].filter(Boolean).join('  ');
 
             switchTable[kswitch] = {
@@ -214,10 +214,12 @@ module.exports = function (yargs) {
 
     // format the default-value-string displayed in
     // the right-hand column.
-    function defaultString(value) {
+    function defaultString(value, defaultDescription) {
         if (value === undefined) return null;
 
         var string = '[default: ';
+        
+        if (defaultDescription) return string + defaultDescription + ']';
 
         switch (typeof value) {
             case 'string':

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,6 +1,7 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-var wordwrap = require('wordwrap'),
+var S = require('string'),
+  wordwrap = require('wordwrap'),
   wsize = require('window-size');
 
 module.exports = function (yargs) {
@@ -167,10 +168,7 @@ module.exports = function (yargs) {
                     ? '[required]'
                     : null
                 ,
-                options.default[key] !== undefined
-                    ? '[default: ' + (typeof options.default[key] === 'string' ?
-                    JSON.stringify : String)(options.default[key]) + ']'
-                    : null
+                defaultString(options.default[key])
             ].filter(Boolean).join('  ');
 
             switchTable[kswitch] = {
@@ -212,6 +210,27 @@ module.exports = function (yargs) {
     self.showHelp = function (level) {
         level = level || 'error';
         console[level](self.help());
+    }
+
+    // format the default-value-string displayed in
+    // the right-hand column.
+    function defaultString(value) {
+        if (value === undefined) return null;
+
+        var string = '[default: ';
+
+        switch (typeof value) {
+            case 'string':
+              string += JSON.stringify(value);
+              break;
+            case 'function':
+              string += '(' + (value.name.length ? S(value.name).dasherize().s : 'generated-value') + ')'
+              break;
+            default:
+              string += value;
+        }
+
+        return string + ']';
     }
 
     // word-wrapped two-column layout used by

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -215,21 +215,23 @@ module.exports = function (yargs) {
     // format the default-value-string displayed in
     // the right-hand column.
     function defaultString(value, defaultDescription) {
-        if (value === undefined) return null;
-
         var string = '[default: ';
-        
-        if (defaultDescription) return string + defaultDescription + ']';
 
-        switch (typeof value) {
-            case 'string':
-              string += JSON.stringify(value);
-              break;
-            case 'function':
-              string += '(' + (value.name.length ? S(value.name).dasherize().s : 'generated-value') + ')'
-              break;
-            default:
-              string += value;
+        if (value === undefined) return null;
+        
+        if (defaultDescription) {
+          string += defaultDescription;
+        } else {
+          switch (typeof value) {
+              case 'string':
+                string += JSON.stringify(value);
+                break;
+              case 'function':
+                string += '(' + (value.name.length ? S(value.name).dasherize().s : 'generated-value') + ')'
+                break;
+              default:
+                string += value;
+          }
         }
 
         return string + ']';

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "string": "^3.0.0",
     "window-size": "0.1.0",
     "wordwrap": "0.0.2"
   },

--- a/test/parser.js
+++ b/test/parser.js
@@ -160,16 +160,6 @@ describe('parser tests', function () {
         parse.should.have.property('_').and.deep.equal(['moo']);
     });
 
-    it('should set boolean options to false by default', function () {
-        var parse = yargs(['moo'])
-            .boolean(['t', 'verbose'])
-            .default('verbose', false)
-            .default('t', false).argv;
-        parse.should.have.property('verbose', false).and.be.a('boolean');
-        parse.should.have.property('t', false).and.be.a('boolean');
-        parse.should.have.property('_').and.deep.equal(['moo']);
-    });
-
     it('should allow defining options as boolean in groups', function () {
         var parse = yargs([ '-x', '-z', 'one', 'two', 'three' ])
             .boolean(['x','y','z']).argv;
@@ -324,26 +314,6 @@ describe('parser tests', function () {
         argv.should.have.property('z', 55);
         argv.should.have.property('zm', 55);
         argv.should.have.property('f', 11);
-    });
-
-    it('should define option as boolean and set default to true', function () {
-        var argv = yargs.options({
-            sometrue: {
-                boolean: true,
-                default: true
-            }
-        }).argv;
-        argv.should.have.property('sometrue', true);
-    });
-
-    it('should define option as boolean and set default to false', function () {
-        var argv = yargs.options({
-            somefalse: {
-                boolean: true,
-                default: false
-            }
-        }).argv;
-        argv.should.have.property('somefalse', false);
     });
 
     describe('dot notation', function() {
@@ -680,6 +650,46 @@ describe('parser tests', function () {
                     argv2.parse([ ]).flag.should.be.false;
                 });
             });
+        });
+
+        it('should define option as boolean and set default to true', function () {
+            var argv = yargs.options({
+                sometrue: {
+                    boolean: true,
+                    default: true
+                }
+            }).argv;
+            argv.should.have.property('sometrue', true);
+        });
+
+        it('should define option as boolean and set default to false', function () {
+            var argv = yargs.options({
+                somefalse: {
+                    boolean: true,
+                    default: false
+                }
+            }).argv;
+            argv.should.have.property('somefalse', false);
+        });
+
+        it('should set boolean options to false by default', function () {
+            var parse = yargs(['moo'])
+                .boolean(['t', 'verbose'])
+                .default('verbose', false)
+                .default('t', false).argv;
+            parse.should.have.property('verbose', false).and.be.a('boolean');
+            parse.should.have.property('t', false).and.be.a('boolean');
+            parse.should.have.property('_').and.deep.equal(['moo']);
+        });
+
+        it('should allow function to be provided as default value', function() {
+            var argv = yargs([])
+                .default('file', function() {
+                  return 'foo.txt';
+                })
+                .argv;
+
+            argv.file.should.equal('foo.txt');
         });
     });
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -946,5 +946,20 @@ describe('usage tests', function () {
 
           r.logs[0].should.include('default: (random-number)');
       });
+
+      it('default-description take precedence if one is provided', function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .help('h')
+                  .default('f', function randomNumber() {
+                    return Math.random() * 256;
+                  }, 'foo-description')
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs[0].should.include('default: foo-description');
+      });
     });
 });

--- a/test/usage.js
+++ b/test/usage.js
@@ -915,4 +915,36 @@ describe('usage tests', function () {
           ]);
       });
     });
+
+    describe('default', function() {
+      it('should indicate that the default is a generated-value, if function is provided', function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .help('h')
+                  .default('f', function() {
+                    return 99;
+                  })
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs[0].should.include('default: (generated-value)');
+      });
+
+      it('if a named function is provided, should use name rather than (generated-value)', function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .help('h')
+                  .default('f', function randomNumber() {
+                    return Math.random() * 256;
+                  })
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs[0].should.include('default: (random-number)');
+      });
+    });
 });


### PR DESCRIPTION
Using a function as a default value resulted in a broken usage message, see #60.

Providing an unnamed function for a default will now result in these usage instructions:

`[default: (generated-value)]`

You can also now provide a named function:

```js
var argv = require('./')
  .help('h')
  .default('random', function randomValue() {
    return Math.random() * 256;
  }).argv;
```

which would result in the usage instruction:

`[default: (random-value)]`

what do you think @kilianc?