### PR TITLE
improve and add tests to reset() command

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,42 @@ By default, yargs exits the process when the user passes a help flag, uses the `
 
 Parse `args` instead of `process.argv`. Returns the `argv` object.
 
+.reset()
+--------
+
+Reset the argument object built up so far. This is useful for
+created nested command line interaces.
+
+```js
+var yargs = require('./yargs')
+  .usage('$0 command')
+  .command('hello', 'hello command')
+  .command('world', 'world command')
+  .demand(1, 'must provide a valid command'),
+  argv = yargs.argv,
+  command = argv._[0];
+
+if (command === 'hello') {
+  yargs.reset()
+    .usage('$0 hello')
+    .help('h')
+    .example('$0 hello', 'print the hello message!')
+    .argv
+
+  console.log('hello!');
+} else if (command === 'world'){
+  yargs.reset()
+    .usage('$0 world')
+    .help('h')
+    .example('$0 world', 'print the world message!')
+    .argv
+
+  console.log('world!');
+} else {
+  yargs.showHelp();
+}
+```
+
 .argv
 -----
 

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Parse `args` instead of `process.argv`. Returns the `argv` object.
 --------
 
 Reset the argument object built up so far. This is useful for
-created nested command line interaces.
+creating nested command line interfaces.
 
 ```js
 var yargs = require('./yargs')

--- a/index.js
+++ b/index.js
@@ -21,8 +21,8 @@ Object.keys(inst).forEach(function (key) {
 var exports = module.exports = Argv;
 function Argv (processArgs, cwd) {
     var self = {};
-    var usage = Usage(self);
-    var validation = Validation(self, usage);
+    var usage = null;
+    var validation = null;
 
     if (!cwd) cwd = process.cwd();
 
@@ -43,7 +43,10 @@ function Argv (processArgs, cwd) {
     }
 
     var options;
-    self.resetOptions = function () {
+    self.resetOptions = self.reset = function () {
+        // put yargs back into its initial
+        // state, this is useful for creating a
+        // nested CLI.
         options = {
             array: [],
             boolean: [],
@@ -56,6 +59,16 @@ function Argv (processArgs, cwd) {
             normalize: [],
             config: []
         };
+
+        usage = Usage(self); // handle usage output.
+        validation = Validation(self, usage); // handle arg validation.
+
+        demanded = {};
+
+        exitProcess = true;
+        helpOpt = null;
+        versionOpt = null;
+
         return self;
     };
     self.resetOptions();
@@ -304,6 +317,14 @@ function Argv (processArgs, cwd) {
 
         return usage.help();
     };
+
+    self.getUsageInstance = function () {
+        return usage;
+    };
+
+    self.getValidationInstance = function () {
+        return validation;
+    }
 
     Object.defineProperty(self, 'argv', {
         get : function () {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -135,6 +135,9 @@ module.exports = function (yargs, usage) {
             implied[key] = value;
         }
     };
+    self.getImplied = function() {
+        return implied;
+    }
 
     self.implications = function(argv) {
         var implyFail = [];

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -134,4 +134,42 @@ describe('yargs dsl tests', function () {
           r.exit.should.eql(true);
         });
     });
+
+    describe('reset', function() {
+        it('should put yargs back into its initial state', function() {
+          // create a command line with all the things.
+          // so that we can confirm they're reset.
+          var y = yargs(['--help'])
+            .help('help')
+            .command('foo', 'bar')
+            .default('foo', 'bar')
+            .describe('foo', 'foo variable')
+            .demand('foo')
+            .string('foo')
+            .alias('foo', 'bar')
+            .string('foo')
+            .implies('foo', 'snuh')
+            .exitProcess(false)  // defaults to true.
+            .reset();
+
+          var emptyOptions = {
+            array: [],
+            boolean: [],
+            string: [],
+            alias: {},
+            default: {},
+            defaultDescription: {},
+            requiresArg: [],
+            count: [],
+            normalize: [],
+            config: []
+          };
+
+          expect(y.getOptions()).to.deep.equal(emptyOptions);
+          expect(y.getUsageInstance().getDescriptions()).to.deep.equal({});
+          expect(y.getValidationInstance().getImplied()).to.deep.equal({});
+          expect(y.getExitProcess()).to.equal(true);
+          expect(y.getDemanded()).to.deep.equal({});
+        });
+    });
 });


### PR DESCRIPTION
* added tests for `reset()` method, it now does a better job of getting yargs into an initial state.
* a better reset command makes it easier to create a nested argument parser \o/
  * I've added an example of this to the README.
  * I think this is a clean way of addressing the feature request put forward in #53