### PR TITLE
implemented nargs feature, based on Python's argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,24 @@ regardless of whether they resemble numbers.
 Tell the parser to interpret `key` as an array. If `.array('foo')` is set,
 `--foo bar` will be parsed as `['bar']` rather than as `'bar'`.
 
+.nargs(key, count)
+-----------
+
+The number of arguments that should be consumed after a key. This can be a
+useful hint to prevent parsing ambiguity:
+
+```js
+var argv = require('yargs')
+  .nargs('token', 1)
+  .parse(['--token', '-my-token']);
+```
+
+parses as:
+
+`{ _: [], token: '-my-token', '$0': 'node test' }`
+
+Optionally `.nargs()` can take an object of `key`/`narg` pairs.
+
 .config(key)
 ------------
 

--- a/README.md
+++ b/README.md
@@ -315,23 +315,25 @@ s.on('end', function () {
 ````
 
 ***
+    $ node line_count.js count
+    Usage: node test.js <command> [options]
 
-    $ node line_count.js
-    Count the lines in a file.
-    Usage: node ./line_count.js
-
-    Examples:
-      node ./line_count.js -f   count the lines in the given file
+    Commands:
+      count    Count the lines in a file
 
     Options:
-      -f, --file  Load a file  [required]
+      -f, --file  Load a file        [required]
+      -h, --help  Show help
+
+    Examples:
+      node test.js count -f foo.js    count the lines in the given file
 
     Missing required arguments: f
 
-    $ node line_count.js --file line_count.js
+    $ node line_count.js count --file line_count.js
     20
 
-    $ node line_count.js -f line_count.js
+    $ node line_count.js count -f line_count.js
     20
 
 methods

--- a/README.md
+++ b/README.md
@@ -288,13 +288,18 @@ line_count.js
 ````javascript
 #!/usr/bin/env node
 var argv = require('yargs')
-    .usage('Count the lines in a file.\nUsage: $0')
-    .example('$0 -f', 'count the lines in the given file')
+    .usage('Usage: $0 <command> [options]')
+    .command('count', 'Count the lines in a file')
+    .demand(1)
+    .example('$0 count -f foo.js', 'count the lines in the given file')
     .demand('f')
     .alias('f', 'file')
+    .nargs('f', 1)
     .describe('f', 'Load a file')
-    .argv
-;
+    .help('h')
+    .alias('h', 'help')
+    .epilog('copyright 2015')
+    .argv;
 
 var fs = require('fs');
 var s = fs.createReadStream(argv.file);
@@ -823,15 +828,15 @@ installation
 
 With [npm](http://github.com/isaacs/npm), just do:
 
-    `npm install yargs`
+    npm install yargs
 
 or clone this project on github:
 
-    `git clone http://github.com/bcoe/yargs.git`
+    git clone http://github.com/bcoe/yargs.git
 
 To run the tests with npm, just do:
 
-    `npm test`
+    npm test
 
 inspired by
 ===========

--- a/README.md
+++ b/README.md
@@ -823,16 +823,15 @@ installation
 
 With [npm](http://github.com/isaacs/npm), just do:
 
-    npm install yargs
+    `npm install yargs`
 
 or clone this project on github:
 
-    git clone http://github.com/bcoe/yargs.git
+    `git clone http://github.com/bcoe/yargs.git`
 
-To run the tests with [expresso](http://github.com/visionmedia/expresso),
-just do:
+To run the tests with npm, just do:
 
-    expresso
+    `npm test`
 
 inspired by
 ===========

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ s.on('end', function () {
     Examples:
       node test.js count -f foo.js    count the lines in the given file
 
+    copyright 2015
+
     Missing required arguments: f
 
     $ node line_count.js count --file line_count.js

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function Argv (processArgs, cwd) {
             array: [],
             boolean: [],
             string: [],
+            narg: {},
             key: {},
             alias: {},
             default: {},
@@ -81,6 +82,17 @@ function Argv (processArgs, cwd) {
 
     self.array = function (arrays) {
         options.array.push.apply(options.array, [].concat(arrays));
+        return self;
+    }
+
+    self.nargs = function (key, n) {
+        if (typeof key === 'object') {
+            Object.keys(key).forEach(function(k) {
+                self.nargs(k, key[k]);
+            });
+        } else {
+            options.narg[key] = n;
+        }
         return self;
     }
 
@@ -233,6 +245,9 @@ function Argv (processArgs, cwd) {
             }
             if ('default' in opt) {
                 self.default(key, opt.default);
+            }
+            if ('nargs' in opt) {
+                self.nargs(key, opt.nargs);
             }
             if (opt.boolean || opt.type === 'boolean') {
                 self.boolean(key);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,7 +6,6 @@ var camelCase = require('camelcase'),
 
 module.exports = function (args, opts) {
     if (!opts) opts = {};
-
     var flags = { arrays: {}, bools : {}, strings : {}, counts: {}, normalize: {}, configs: {} };
 
     [].concat(opts['array']).filter(Boolean).forEach(function (key) {
@@ -84,18 +83,24 @@ module.exports = function (args, opts) {
         // -- seperated by space.
         else if (arg.match(/^--.+/)) {
             var key = arg.match(/^--(.+)/)[1];
-            var next = args[i + 1];
-            if (next !== undefined && !next.match(/^-/)
-                && !checkAllAliases(key, flags.bools)) {
-                setArg(key, next);
-                i++;
-            }
-            else if (/^(true|false)$/.test(next)) {
-                setArg(key, next);
-                i++;
-            }
-            else {
-                setArg(key, defaultForType(guessType(key, flags)));
+
+            if (checkAllAliases(key, opts.narg)) {
+                i = eatNargs(i, key, args);
+            } else {
+                var next = args[i + 1];
+
+                if (next !== undefined && !next.match(/^-/)
+                    && !checkAllAliases(key, flags.bools)) {
+                    setArg(key, next);
+                    i++;
+                }
+                else if (/^(true|false)$/.test(next)) {
+                    setArg(key, next);
+                    i++;
+                }
+                else {
+                    setArg(key, defaultForType(guessType(key, flags)));
+                }
             }
         }
         // dot-notation flag seperated by '='.
@@ -133,14 +138,12 @@ module.exports = function (args, opts) {
                     setArg(letters[j], next)
                     continue;
                 }
-
                 if (/[A-Za-z]/.test(letters[j])
                     && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
                     setArg(letters[j], next);
                     broken = true;
                     break;
                 }
-
                 if (letters[j+1] && letters[j+1].match(/\W/)) {
                     setArg(letters[j], arg.slice(j+2));
                     broken = true;
@@ -152,18 +155,23 @@ module.exports = function (args, opts) {
             }
 
             var key = arg.slice(-1)[0];
+
             if (!broken && key !== '-') {
-                if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
-                    && !checkAllAliases(key, flags.bools)) {
-                    setArg(key, args[i+1]);
-                    i++;
-                }
-                else if (args[i+1] && /true|false/.test(args[i+1])) {
-                    setArg(key, args[i+1]);
-                    i++;
-                }
-                else {
-                    setArg(key, defaultForType(guessType(key, flags)));
+                if (checkAllAliases(key, opts.narg)) {
+                    i = eatNargs(i, key, args);
+                } else {
+                    if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
+                        && !checkAllAliases(key, flags.bools)) {
+                        setArg(key, args[i+1]);
+                        i++;
+                    }
+                    else if (args[i+1] && /true|false/.test(args[i+1])) {
+                        setArg(key, args[i+1]);
+                        i++;
+                    }
+                    else {
+                        setArg(key, defaultForType(guessType(key, flags)));
+                    }
                 }
             }
         }
@@ -184,6 +192,20 @@ module.exports = function (args, opts) {
     notFlags.forEach(function(key) {
         argv._.push(key);
     });
+
+    // how many arguments should we consume, based
+    // on the nargs option?
+    function eatNargs (i, key, args) {
+        var toEat = checkAllAliases(key, opts.narg);
+
+        if (args.length - (i + 1) < toEat) throw Error('not enough arguments following: ' + key);
+
+        for (var ii = i + 1; ii < (toEat + i + 1); ii++) {
+            setArg(key, args[ii]);
+        }
+
+        return (i + toEat);
+    }
 
     function setArg (key, val) {
         // handle parsing boolean arguments --foo=true --bar false.
@@ -340,7 +362,7 @@ module.exports = function (args, opts) {
           toCheck = [].concat(aliases[key] || [], key);
 
         toCheck.forEach(function(key) {
-            if (flag[key]) isSet = true;
+            if (flag[key]) isSet = flag[key];
         });
 
         return isSet;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yargs",
-  "version": "3.3.3",
+  "version": "3.4.3",
   "description": "Light-weight option parsing with an argv hash. No optstrings attached.",
   "main": "./index.js",
   "files": [

--- a/test/parser.js
+++ b/test/parser.js
@@ -919,4 +919,57 @@ describe('parser tests', function () {
             Array.isArray(result.c).should.equal(true);
         });
     });
+
+    describe('nargs', function() {
+        it('should allow the number of arguments following a key to be specified', function() {
+            var result = yargs().nargs('foo', 2)
+              .parse([ '--foo', 'apple', 'bar' ]);
+
+            Array.isArray(result.foo).should.equal(true);
+            result.foo[0].should.equal('apple');
+            result.foo[1].should.equal('bar');
+        });
+
+        it('should raise an exception if there are not enough arguments following key', function() {
+            expect(function() {
+              var result = yargs().nargs('foo', 2).
+                parse([ '--foo', 'apple']);
+            }).to.throw('not enough arguments following: foo');
+        });
+
+        it('nargs is applied to aliases', function() {
+            var result = yargs().nargs('foo', 2)
+              .alias('foo', 'bar')
+              .parse([ '--bar', 'apple', 'bar' ]);
+
+            Array.isArray(result.foo).should.equal(true);
+            result.foo[0].should.equal('apple');
+            result.foo[1].should.equal('bar');
+        });
+
+        it("should apply nargs to flag arguments", function() {
+            var result = yargs()
+              .option('f', {
+                nargs: 2
+              }).parse([ '-f', 'apple', 'bar', 'blerg' ]);
+
+            result.f[0].should.equal('apple');
+            result.f[1].should.equal('bar');
+            result._[0].should.equal('blerg');
+        });
+
+        it("allows multiple nargs to be set at the same time", function() {
+            var result = yargs().nargs({
+                'foo': 2,
+                'bar': 1
+              })
+              .parse([ '--foo', 'apple', 'bar', '--bar', 'banana', '-f' ]);
+
+            Array.isArray(result.foo).should.equal(true);
+            result.foo[0].should.equal('apple');
+            result.foo[1].should.equal('bar');
+            result.bar.should.equal('banana');
+            result.f.should.equal(true);
+        });
+    });
 });

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -159,6 +159,7 @@ describe('yargs dsl tests', function () {
             alias: {},
             default: {},
             key: {},
+            narg: {},
             defaultDescription: {},
             requiresArg: [],
             count: [],


### PR DESCRIPTION
I have implemented `nargs` functionality based on Python's argparse module (see #15). Being able to specify the number of arguments following a flag can help eliminate ambiguity.

e.g., it allows an argument to accept values that would usually be parsed as additional command line arguments (see #78)

```js
var argv = require('yargs')
  .nargs('token', 1)
  .parse(['--token', '--my-cool-token']);
```