### PR TITLE
fix: replace $0 in epilog

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -199,9 +199,9 @@ module.exports = function (yargs) {
 
         // the usage string.
         if (epilog) {
-            var e = epilog;
-            if (wrap) e = wordwrap(0, wrap)(epilog);
-            help.push(epilog, '');
+            var e = epilog.replace(/\$0/g, yargs.$0);
+            if (wrap) e = wordwrap(0, wrap)(e);
+            help.push(e, '');
         }
 
         return help.join('\n');
@@ -218,7 +218,7 @@ module.exports = function (yargs) {
         var string = '[default: ';
 
         if (value === undefined) return null;
-        
+
         if (defaultDescription) {
           string += defaultDescription;
         } else {

--- a/test/usage.js
+++ b/test/usage.js
@@ -939,6 +939,23 @@ describe('usage tests', function () {
               'Missing required arguments: y'
           ]);
       });
+
+      it('replaces $0 in epilog string', function() {
+          var r = checkUsage(function () {
+              return yargs('')
+                  .epilog("Try '$0 --long-help' for more information")
+                  .demand('y')
+                  .wrap(null)
+                  .argv;
+          });
+
+          r.errors.join('\n').split(/\n+/).should.deep.equal([
+              'Options:',
+              '  -y  [required]',
+              'Try \'./usage --long-help\' for more information',
+              'Missing required arguments: y'
+          ]);
+      });
     });
 
     describe('default', function() {


### PR DESCRIPTION
This PR fixes some small typos within the epilog handling for the following use case:
```js
yargs('')
  .epilog("Try '$0 --long-help' for more information")
```