### PR TITLE
switch from string to camelcase/decamelize

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var path = require('path');
-var Parser = require('./lib/parser');
-var Usage = require('./lib/usage');
-var Validation = require('./lib/validation');
+var path = require('path'),
+  Parser = require('./lib/parser'),
+  Usage = require('./lib/usage'),
+  Validation = require('./lib/validation');
 
 /*  Hack an instance of Argv with process.argv into Argv
     so people can do

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,8 +1,8 @@
 // fancy-pants parsing of argv, originally forked
 // from minimist: https://www.npmjs.com/package/minimist
-var fs = require('fs'),
-  path = require('path'),
-  S = require('string');
+var camelCase = require('camelcase'),
+  fs = require('fs'),
+  path = require('path');
 
 module.exports = function (args, opts) {
     if (!opts) opts = {};
@@ -33,10 +33,6 @@ module.exports = function (args, opts) {
         flags.configs[key] = true;
     });
 
-    function toCamelCase(str) {
-        return S(str).camelize().s;
-    }
-
     var aliases = {},
         newAliases = {};
 
@@ -46,7 +42,7 @@ module.exports = function (args, opts) {
     var defaults = opts['default'] || {};
     Object.keys(defaults).forEach(function (key) {
         if (/-/.test(key) && !opts.alias[key]) {
-            var c = toCamelCase(key);
+            var c = camelCase(key);
             aliases[key] = aliases[key] || [];
             // don't allow the same key to be added multiple times.
             if (aliases[key].indexOf(c) === -1) {
@@ -196,7 +192,7 @@ module.exports = function (args, opts) {
         }
 
         if (/-/.test(key) && !(aliases[key] && aliases[key].length)) {
-            var c = toCamelCase(key);
+            var c = camelCase(key);
             aliases[key] = [c];
             newAliases[c] = true;
         }
@@ -325,7 +321,7 @@ module.exports = function (args, opts) {
         // For "--option-name", also set argv.optionName
         aliases[key].concat(key).forEach(function (x) {
             if (/-/.test(x)) {
-                var c = toCamelCase(x);
+                var c = camelCase(x);
                 aliases[key].push(c);
                 newAliases[c] = true;
             }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,6 +1,6 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-var S = require('string'),
+var decamelize = require('decamelize'),
   wordwrap = require('wordwrap'),
   wsize = require('window-size');
 
@@ -227,7 +227,7 @@ module.exports = function (yargs) {
                 string += JSON.stringify(value);
                 break;
               case 'function':
-                string += '(' + (value.name.length ? S(value.name).dasherize().s : 'generated-value') + ')'
+                string += '(' + (value.name.length ? decamelize(value.name, '-') : 'generated-value') + ')'
                 break;
               default:
                 string += value;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "string": "^3.0.0",
+    "camelcase": "^1.0.2",
+    "decamelize": "^1.0.0",
     "window-size": "0.1.0",
     "wordwrap": "0.0.2"
   },


### PR DESCRIPTION
We were using the `string` library for camelcase/decamelize helpers, unfortunately string modifies the underlying string prototype which can introduce bugs.

I've switched us to using:

https://www.npmjs.com/package/decamelize

and

https://www.npmjs.com/package/camelcase

we can pull in more string helpers as needed.

fixes #106 