### PR TITLE
fix: count should not consume the next argument

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -90,7 +90,8 @@ module.exports = function (args, opts) {
                 var next = args[i + 1];
 
                 if (next !== undefined && !next.match(/^-/)
-                    && !checkAllAliases(key, flags.bools)) {
+                    && !checkAllAliases(key, flags.bools)
+                    && !checkAllAliases(key, flags.counts)) {
                     setArg(key, next);
                     i++;
                 }
@@ -113,7 +114,8 @@ module.exports = function (args, opts) {
             var key = arg.match(/^-(.\..+)/)[1];
             var next = args[i + 1];
             if (next !== undefined && !next.match(/^-/)
-                && !checkAllAliases(key, flags.bools)) {
+                && !checkAllAliases(key, flags.bools)
+                && !checkAllAliases(key, flags.counts)) {
                 setArg(key, next);
                 i++;
             }
@@ -161,7 +163,8 @@ module.exports = function (args, opts) {
                     i = eatNargs(i, key, args);
                 } else {
                     if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
-                        && !checkAllAliases(key, flags.bools)) {
+                        && !checkAllAliases(key, flags.bools)
+                        && !checkAllAliases(key, flags.counts)) {
                         setArg(key, args[i+1]);
                         i++;
                     }
@@ -209,7 +212,7 @@ module.exports = function (args, opts) {
 
     function setArg (key, val) {
         // handle parsing boolean arguments --foo=true --bar false.
-        if (checkAllAliases(key, flags.bools)) {
+        if (checkAllAliases(key, flags.bools) || checkAllAliases(key, flags.counts)) {
           if (typeof val === 'string') val = val === 'true';
         }
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -871,6 +871,17 @@ describe('parser tests', function () {
             parsed = yargs(['--verbose', '--verbose', '-v', '-vv']).count('verbose').alias('v', 'verbose').argv;
             parsed.verbose.should.equal(5);
         });
+
+        it('should not consume the next argument', function () {
+            var parsed;
+            parsed = yargs([ '-v', 'moo' ]).count('v').argv;
+            parsed.v.should.equal(1);
+            parsed.should.have.property('_').and.deep.equal(['moo']);
+
+            parsed = yargs([ '--verbose', 'moomoo', '--verbose' ]).count('verbose').argv;
+            parsed.verbose.should.equal(2);
+            parsed.should.have.property('_').and.deep.equal(['moomoo']);
+        });
     });
 
     describe('array', function() {


### PR DESCRIPTION
Actually, `count` drops the next argument:
```js
require('yargs').count('verbose').parse([ '--verbose', 'I AM LOST!', 'foo' ])
{ _: [ 'foo' ], verbose: 1, '$0': 'node' }
```
That's because `count` and `boolean` are handled somewhat differently.

Maybe this PR needs some refactoring as I've only doubled the `boolean` checks.