### PR TITLE
yargs was parsing more times than it should

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,8 +360,6 @@ function Argv (processArgs, cwd) {
         // a function can be provided
         if (fn) completion.registerFunction(fn);
 
-        if (!self.parsed) parseArgs(processArgs); // run parser, if it has not already been executed.
-
         return self;
     };
 
@@ -481,8 +479,12 @@ function rebase (base, dir) {
 */
 function sigletonify(inst) {
     Object.keys(inst).forEach(function (key) {
-        Argv[key] = typeof inst[key] == 'function'
-            ? inst[key].bind(inst)
-            : inst[key];
+        if (key === 'argv') {
+          Argv.__defineGetter__(key, inst.__lookupGetter__(key));
+        } else {
+          Argv[key] = typeof inst[key] == 'function'
+              ? inst[key].bind(inst)
+              : inst[key];
+        }
     });
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "hashish": "0.0.4",
     "mocha": "2.1.0",
     "mocha-lcov-reporter": "0.0.1",
-    "mocoverage": "^1.0.0",
-    "once": "^1.3.1"
+    "mocoverage": "^1.0.0"
   },
   "scripts": {
     "test": "mocha --check-leaks --ui exports --require blanket -R mocoverage"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "hashish": "0.0.4",
     "mocha": "2.1.0",
     "mocha-lcov-reporter": "0.0.1",
-    "mocoverage": "^1.0.0"
+    "mocoverage": "^1.0.0",
+    "once": "^1.3.1"
   },
   "scripts": {
     "test": "mocha --check-leaks --ui exports --require blanket -R mocoverage"

--- a/test/usage.js
+++ b/test/usage.js
@@ -3,7 +3,7 @@ var should = require('chai').should(),
     yargs = require('../');
 
 describe('usage tests', function () {
-  
+
     beforeEach(function() {
       yargs.reset();
     });
@@ -789,6 +789,7 @@ describe('usage tests', function () {
 
         r.result.should.match(/foo/);
     });
+
 
     describe('wrap', function() {
         it('should wrap argument descriptions onto multiple lines', function() {


### PR DESCRIPTION
The act of creating the `Argv` singleton was causing the yargs getter to invoke, and causing premature parsing.