### PR TITLE
adjust the way yargs evaluates functions passed as defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,10 @@ function Argv (processArgs, cwd) {
             });
         }
         else {
+            if (typeof value === 'function') {
+                defaultDescription = usage.functionDescription(value, defaultDescription);
+                value = value.call();
+            }
             options.defaultDescription[key] = defaultDescription;
             options.default[key] = value;
         }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,6 +4,10 @@ var camelCase = require('camelcase'),
   fs = require('fs'),
   path = require('path');
 
+function increment (orig) {
+    return orig !== undefined ? orig + 1 : 0;
+}
+
 module.exports = function (args, opts) {
     if (!opts) opts = {};
     var flags = { arrays: {}, bools : {}, strings : {}, counts: {}, normalize: {}, configs: {} };
@@ -225,7 +229,7 @@ module.exports = function (args, opts) {
         var value = !checkAllAliases(key, flags.strings) && isNumber(val) ? Number(val) : val;
 
         if (checkAllAliases(key, flags.counts)) {
-            value = function(orig) { return orig !== undefined ? orig + 1 : 0; };
+            value = increment;
         }
 
         var splitKey = key.split('.');
@@ -322,8 +326,8 @@ module.exports = function (args, opts) {
         });
 
         var key = keys[keys.length - 1];
-        if (typeof value === 'function') {
-            o[key] = value(o[key]);
+        if (value === increment) {
+            o[key] = increment(o[key]);
         }
         else if (o[key] === undefined && checkAllAliases(key, flags.arrays)) {
             o[key] = Array.isArray(value) ? value : [value];

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -211,6 +211,14 @@ module.exports = function (yargs) {
         console[level](self.help());
     }
 
+    self.functionDescription = function (fn, defaultDescription) {
+        if (defaultDescription) {
+            return defaultDescription;
+        }
+        var description = fn.name ? decamelize(fn.name, '-') : 'generated-value';
+        return ['(', description, ')'].join('');
+    }
+
     // format the default-value-string displayed in
     // the right-hand column.
     function defaultString(value, defaultDescription) {
@@ -224,9 +232,6 @@ module.exports = function (yargs) {
           switch (typeof value) {
               case 'string':
                 string += JSON.stringify(value);
-                break;
-              case 'function':
-                string += '(' + (value.name.length ? decamelize(value.name, '-') : 'generated-value') + ')'
                 break;
               default:
                 string += value;


### PR DESCRIPTION
This paves the way for cleaner implementation of #127 (as in: no need for `noEval` flag)