### PR TITLE
the chaining API now cares less about key ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,6 @@ function Argv (processArgs, cwd) {
     self.resetOptions();
 
     self.boolean = function (bools) {
-        ([].concat(bools)).forEach(function(key) {
-            options.key[key] = true;
-        });
         options.boolean.push.apply(options.boolean, [].concat(bools));
         return self;
     };

--- a/index.js
+++ b/index.js
@@ -74,6 +74,9 @@ function Argv (processArgs, cwd) {
     self.resetOptions();
 
     self.boolean = function (bools) {
+        ([].concat(bools)).forEach(function(key) {
+            options.key[key] = true;
+        });
         options.boolean.push.apply(options.boolean, [].concat(bools));
         return self;
     };
@@ -170,7 +173,7 @@ function Argv (processArgs, cwd) {
                 demanded[keys] = { msg: msg };
             }
             else if (msg === true || typeof msg === 'undefined') {
-                demanded[keys] = { msg: null };
+                demanded[keys] = { msg: undefined };
             }
         }
 
@@ -221,6 +224,7 @@ function Argv (processArgs, cwd) {
     self.defaults = self.default;
 
     self.describe = function (key, desc) {
+        options.key[key] = true;
         usage.describe(key, desc);
         return self;
     };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -47,11 +47,6 @@ module.exports = function (args, opts) {
         if (/-/.test(key) && !opts.alias[key]) {
             var c = camelCase(key);
             aliases[key] = aliases[key] || [];
-            // don't allow the same key to be added multiple times.
-            if (aliases[key].indexOf(c) === -1) {
-                aliases[key] = (aliases[key] || []).concat(c);
-                newAliases[c] = true;
-            }
         }
         (aliases[key] || []).forEach(function (alias) {
             defaults[alias] = defaults[key];

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -93,6 +93,8 @@ module.exports = function (yargs) {
     };
 
     self.help = function () {
+        normalizeAliases();
+
         var demanded = yargs.getDemanded(),
             options = yargs.getOptions(),
             keys = Object.keys(
@@ -156,10 +158,11 @@ module.exports = function (yargs) {
             var desc = descriptions[key] || '';
             var type = null;
 
-            if (options.boolean[key]) type = '[boolean]';
-            if (options.count[key]) type = '[count]';
-            if (options.string[key]) type = '[string]';
-            if (options.normalize[key]) type = '[string]';
+            if (~options.boolean.indexOf(key)) type = '[boolean]';
+            if (~options.count.indexOf(key)) type = '[count]';
+            if (~options.string.indexOf(key)) type = '[string]';
+            if (~options.normalize.indexOf(key)) type = '[string]';
+            if (~options.array.indexOf(key)) type = '[array]';
 
             var extra = [
                 type,
@@ -204,6 +207,29 @@ module.exports = function (yargs) {
         }
 
         return help.join('\n');
+    };
+
+    // make sure any options set for aliases,
+    // are copied to the keys being aliased.
+    function normalizeAliases () {
+      var options = yargs.getOptions(),
+        demanded = yargs.getDemanded();
+
+      (Object.keys(options.alias) || []).forEach(function(key) {
+          options.alias[key].forEach(function(alias) {
+            // copy descriptions.
+            if (descriptions[alias]) self.describe(key, descriptions[alias]);
+            // copy demanded.
+            if (demanded[alias]) yargs.demand(key, demanded[alias].msg);
+
+            // type messages.
+            if (~options.boolean.indexOf(alias)) yargs.boolean(key);
+            if (~options.count.indexOf(alias)) yargs.count(key);
+            if (~options.string.indexOf(alias)) yargs.string(key);
+            if (~options.normalize.indexOf(alias)) yargs.normalize(key);
+            if (~options.array.indexOf(alias)) yargs.array(key);
+          });
+      });
     };
 
     self.showHelp = function (level) {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
     "wordwrap": "0.0.2"
   },
   "devDependencies": {
-    "blanket": "^1.1.6",
-    "chai": "^1.10.0",
+    "chai": "^2.2.0",
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
-    "mocha": "2.1.0",
-    "mocha-lcov-reporter": "0.0.1",
-    "mocoverage": "^1.0.0"
+    "mocha": "^2.2.1",
+    "mocha-lcov-reporter": "0.0.2",
+    "mocoverage": "^1.0.0",
+    "patched-blanket": "^1.0.1"
   },
   "scripts": {
-    "test": "mocha --check-leaks --ui exports --require blanket -R mocoverage"
+    "test": "mocha --check-leaks --ui exports --require patched-blanket -R mocoverage"
   },
   "repository": {
     "type": "git",

--- a/test/parser.js
+++ b/test/parser.js
@@ -804,7 +804,6 @@ describe('parser tests', function () {
                 result.should.have.property('some-option').that.is.a('string').and.equals('val');
                 result.should.have.property('someOption' ).that.is.a('string').and.equals('val');
             });
-
         }
 
         describe('dashes and camelCase', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1001,4 +1001,65 @@ describe('usage tests', function () {
           r.logs[0].should.include('default: foo-description');
       });
     });
+
+    describe('normalizeAliases', function() {
+      // see #128
+      it("should display 'description' string in help message if set for alias", function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .describe('foo', 'foo option')
+                  .alias('f', 'foo')
+                  .help('h')
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs.join('\n').split(/\n+/).should.deep.equal([
+              'Options:',
+              '  -h         Show help ',
+              '  -f, --foo  foo option',
+              ''
+          ]);
+      });
+
+      it("should display 'required' string in help message if set for alias", function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .demand('foo')
+                  .alias('f', 'foo')
+                  .help('h')
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs.join('\n').split(/\n+/).should.deep.equal([
+              'Options:',
+              '  -h         Show help',
+              '  -f, --foo             [required]',
+              ''
+          ]);
+      });
+
+      it("should display 'type' string in help message if set for alias", function() {
+          var r = checkUsage(function() {
+              return yargs(['-h'])
+                  .string('foo')
+                  .describe('foo', 'bar')
+                  .alias('f', 'foo')
+                  .help('h')
+                  .wrap(null)
+                  .argv
+              ;
+          });
+
+          r.logs.join('\n').split(/\n+/).should.deep.equal([
+              'Options:',
+              '  -h         Show help',
+              '  -f, --foo  bar        [string]',
+              ''
+          ]);
+      });
+    })
 });


### PR DESCRIPTION
if you swapped the order of the `alias` and the `primary` key, when using the chaining API, options such as: `describe`, `default`, `string`, `require`, would not be shown in the usage string.

## In this pull:

* we now make an attempt to apply usage information to both the primary and the alias key.
* coverage has been fixed by using the patched-blanket library.

see: #134, #128
