### PR TITLE
Fix $0 when 'node' or 'iojs' in script path

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ function Argv (processArgs, cwd) {
                 ? b : x
         })
         .join(' ').trim();
-    ;
 
     if (process.env._ != undefined && process.argv[1] == process.env._) {
         self.$0 = process.env._.replace(

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Argv (processArgs, cwd) {
         .map(function (x) {
             // ignore the node bin, specify this in your
             // bin file with #!/usr/bin/env node
-            if (~x.indexOf('node') || ~x.indexOf('iojs')) return;
+            if (/^(node|iojs)\b/.test(x)) return;
             var b = rebase(cwd, x);
             return x.match(/^\//) && b.length < x.length
                 ? b : x

--- a/index.js
+++ b/index.js
@@ -20,10 +20,10 @@ function Argv (processArgs, cwd) {
 
     self.$0 = process.argv
         .slice(0,2)
-        .map(function (x) {
+        .map(function (x, i) {
             // ignore the node bin, specify this in your
             // bin file with #!/usr/bin/env node
-            if (/^(node|iojs)\b/.test(x)) return;
+            if (i == 0 && /\b(node|iojs)$/.test(x)) return;
             var b = rebase(cwd, x);
             return x.match(/^\//) && b.length < x.length
                 ? b : x

--- a/test/usage.js
+++ b/test/usage.js
@@ -1142,6 +1142,12 @@ describe('usage tests', function () {
             });
         });
 
+        it('is detected correctly when argv contains "/usr/bin/node"', function() {
+            mockProcessArgv(['/usr/bin/node', 'script.js'], function() {
+                yargs([]).$0.should.equal('script.js');
+            });
+        });
+
         it('is detected correctly when dirname contains "node"', function() {
             mockProcessArgv(['/code/node/script.js'], function() {
                 yargs([]).$0.should.equal('/code/node/script.js');
@@ -1156,6 +1162,12 @@ describe('usage tests', function () {
 
         it('is detected correctly when argv contains "iojs"', function() {
             mockProcessArgv(['iojs', 'script.js'], function() {
+                yargs([]).$0.should.equal('script.js');
+            });
+        });
+
+        it('is detected correctly when argv contains "/usr/bin/iojs"', function() {
+            mockProcessArgv(['/usr/bin/iojs', 'script.js'], function() {
                 yargs([]).$0.should.equal('script.js');
             });
         });

--- a/test/usage.js
+++ b/test/usage.js
@@ -1094,7 +1094,7 @@ describe('usage tests', function () {
       });
     });
 
-    describe('showHelp', function(done) {
+    describe('showHelp', function() {
         // see #143.
         it('should show help regardless of whether argv has been called', function() {
             var r = checkUsage(function () {
@@ -1113,6 +1113,63 @@ describe('usage tests', function () {
                 '  --foo, -f  foo option',
                 ''
             ]);
+        });
+    });
+
+    describe('$0', function() {
+        function mockProcessArgv(argv, cb) {
+            var argvOld = process.argv;
+            process.argv = argv;
+            // cb must be sync for now
+            try {
+                cb();
+                process.argv = argvOld;
+            } catch (err) {
+                process.argv = argvOld;
+                throw err;
+            }
+        }
+
+        it('is detected correctly for a basic script', function() {
+            mockProcessArgv(['script.js'], function() {
+                yargs([]).$0.should.equal('script.js');
+            });
+        });
+
+        it('is detected correctly when argv contains "node"', function() {
+            mockProcessArgv(['node', 'script.js'], function() {
+                yargs([]).$0.should.equal('script.js');
+            });
+        });
+
+        it('is detected correctly when dirname contains "node"', function() {
+            mockProcessArgv(['/code/node/script.js'], function() {
+                yargs([]).$0.should.equal('/code/node/script.js');
+            });
+        });
+
+        it('is detected correctly when dirname and argv contain "node"', function() {
+            mockProcessArgv(['node', '/code/node/script.js'], function() {
+                yargs([]).$0.should.equal('/code/node/script.js');
+            });
+        });
+
+        it('is detected correctly when argv contains "iojs"', function() {
+            mockProcessArgv(['iojs', 'script.js'], function() {
+                yargs([]).$0.should.equal('script.js');
+            });
+        });
+
+        it('is detected correctly when dirname contains "iojs"', function() {
+            mockProcessArgv(['/code/iojs/script.js'], function() {
+                yargs([]).$0.should.equal('/code/iojs/script.js');
+            });
+        });
+
+        it('is detected correctly when dirname and argv contain "iojs"', function() {
+            mockProcessArgv(['iojs', '/code/iojs/script.js'], function() {
+                yargs([]).$0.should.equal('/code/iojs/script.js');
+            });
         });
     });
 });


### PR DESCRIPTION
This was causing `argv.$0` to be `''` for me since a lot of my code files live at `/somedir/node/projectname/file.js`.