### PR TITLE
Fix README example in argument requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ console.log("The area is:", argv.w * argv.h);
 
 ***
 
-    $ ./area.js -w 55 -w 11
+    $ ./area.js -w 55 -h 11
     605
 
     $ node ./area.js -w 4.91 -w 2.51


### PR DESCRIPTION
This example is supposed to be demonstrating argument validation, but the example is wrong here.