### PR TITLE
refactor yargs' table layout logic to use new helper library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - "0.11"
   - "0.12"
   - "iojs"
-after_script: "NODE_ENV=test YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
+after_script: "NODE_ENV=test YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha --require patched-blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -112,7 +112,7 @@ module.exports = function (yargs) {
     // the usage string.
     if (usage) {
       var u = usage.replace(/\$0/g, yargs.$0)
-      ui.div({text: u, padding: [0, 0, 1, 0]})
+      ui.div(u + '\n')
     }
 
     // your application's commands, i.e., non-option
@@ -203,7 +203,7 @@ module.exports = function (yargs) {
     // the usage string.
     if (epilog) {
       var e = epilog.replace(/\$0/g, yargs.$0)
-      ui.div({text: e, padding: [0, 0, 1, 0]})
+      ui.div(e + '\n')
     }
 
     return ui.toString()

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -226,6 +226,10 @@ module.exports = function (yargs) {
       width = Math.max(v[0].length, width)
     })
 
+    // if we've enabled 'wrap' we should limit
+    // the max-width of the left-column.
+    if (wrap) width = Math.min(width, parseInt(wrap * 0.5, 10))
+
     return width
   }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -107,34 +107,27 @@ module.exports = function (yargs) {
       ui = cliui({
         width: wrap,
         wrap: wrap ? true : false
-      }),
-      width
+      })
 
     // the usage string.
     if (usage) {
       var u = usage.replace(/\$0/g, yargs.$0)
-      ui.row({text: u, padding: [0, 0, 1, 0]})
+      ui.div({text: u, padding: [0, 0, 1, 0]})
     }
 
     // your application's commands, i.e., non-option
     // arguments populated in '_'.
     if (commands.length) {
-      ui.row('Commands:')
-
-      // find length of longest command.
-      width = 0
-      commands.forEach(function (command) {
-        width = Math.max(command[0].length, width)
-      })
+      ui.div('Commands:')
 
       commands.forEach(function (command) {
-        ui.row(
-          {text: command[0], padding: [0, 2, 0, 2], width: width + 4},
+        ui.div(
+          {text: command[0], padding: [0, 2, 0, 2], width: maxWidth(commands) + 4},
           {text: command[1]}
         )
       })
 
-      ui.row()
+      ui.div()
     }
 
     // the options table.
@@ -158,13 +151,7 @@ module.exports = function (yargs) {
     }, {})
 
     if (keys.length) {
-      ui.row('Options:')
-
-      // find length of longest switch.
-      width = 0
-      keys.forEach(function (key) {
-        width = Math.max(switches[key].length, width)
-      })
+      ui.div('Options:')
 
       keys.forEach(function (key) {
         var kswitch = switches[key]
@@ -178,44 +165,68 @@ module.exports = function (yargs) {
         if (~options.array.indexOf(key)) type = '[array]'
 
         var extra = [
-          type,
-          demanded[key] ? '[required]' : null,
-          defaultString(options.default[key], options.defaultDescription[key])
-        ].filter(Boolean).join(' ')
+            type,
+            demanded[key] ? '[required]' : null,
+            defaultString(options.default[key], options.defaultDescription[key])
+          ].filter(Boolean).join(' ')
 
-        ui.row(
-          {text: kswitch, padding: [0, 2, 0, 2], width: Math.min(width + 4, parseInt(wrap * 0.3, 10))},
+        ui.span(
+          {text: kswitch, padding: [0, 2, 0, 2], width: maxWidth(switches) + 4},
           desc
         )
 
-        if (extra) ui.row({text: extra, padding: [0, 0, 0, width + 4], align: 'right'})
+        if (extra) ui.div({text: extra, padding: [0, 0, 0, 2], align: 'right'})
+        else ui.div()
       })
 
-      ui.row()
+      ui.div()
     }
 
     // describe some common use-cases for your application.
     if (examples.length) {
-      ui.row('Examples:')
+      ui.div('Examples:')
 
       examples.forEach(function (example) {
         example[0] = example[0].replace(/\$0/g, yargs.$0)
-        ui.row(
-          {text: example[0], padding: [0, 2, 0, 2]},
+      })
+
+      examples.forEach(function (example) {
+        ui.div(
+          {text: example[0], padding: [0, 2, 0, 2], width: maxWidth(examples) + 4},
           example[1]
         )
       })
 
-      ui.row()
+      ui.div()
     }
 
     // the usage string.
     if (epilog) {
       var e = epilog.replace(/\$0/g, yargs.$0)
-      ui.row({text: e, padding: [0, 0, 1, 0]})
+      ui.div({text: e, padding: [0, 0, 1, 0]})
     }
 
     return ui.toString()
+  }
+
+  // return the maximum width of a string
+  // in the left-hand column of a table.
+  function maxWidth (table) {
+    var width = 0
+
+    // table might be of the form [leftColumn],
+    // or {key: leftColumn}}
+    if (!Array.isArray(table)) {
+      table = Object.keys(table).map(function (key) {
+        return [table[key]]
+      })
+    }
+
+    table.forEach(function (v) {
+      width = Math.max(v[0].length, width)
+    })
+
+    return width
   }
 
   // make sure any options set for aliases,

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -279,14 +279,6 @@ module.exports = function (yargs) {
     return string + ']'
   }
 
-  // find longest string in array of strings.
-  /*function longest (xs) {
-    return Math.max.apply(
-      null,
-      xs.map(function (x) { return x.length })
-    )
-  }*/
-
   // guess the width of the console window, max-width 100.
   function windowWidth () {
     return wsize.width ? Math.min(80, wsize.width) : null

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,7 +1,7 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-var decamelize = require('decamelize'),
-  wordwrap = require('wordwrap'),
+var cliui = require('cliui'),
+  decamelize = require('decamelize'),
   wsize = require('window-size')
 
 module.exports = function (yargs) {
@@ -94,40 +94,47 @@ module.exports = function (yargs) {
     normalizeAliases()
 
     var demanded = yargs.getDemanded(),
-    options = yargs.getOptions(),
-    keys = Object.keys(
-      Object.keys(descriptions)
-      .concat(Object.keys(demanded))
-      .concat(Object.keys(options.default))
-      .reduce(function (acc, key) {
-        if (key !== '_') acc[key] = true
-        return acc
-      }, {})
-    )
-
-    var help = keys.length ? [ 'Options:' ] : []
-
-    // your application's commands, i.e., non-option
-    // arguments populated in '_'.
-    if (commands.length) {
-      help.unshift('')
-
-      var commandsTable = {}
-      commands.forEach(function (command) {
-        commandsTable[command[0]] = {
-          desc: command[1],
-          extra: ''
-        }
-      })
-
-      help = ['Commands:'].concat(formatTable(commandsTable, 5), help)
-    }
+      options = yargs.getOptions(),
+      keys = Object.keys(
+        Object.keys(descriptions)
+        .concat(Object.keys(demanded))
+        .concat(Object.keys(options.default))
+        .reduce(function (acc, key) {
+          if (key !== '_') acc[key] = true
+          return acc
+        }, {})
+      ),
+      ui = cliui({
+        width: wrap,
+        wrap: wrap ? true : false
+      }),
+      width
 
     // the usage string.
     if (usage) {
       var u = usage.replace(/\$0/g, yargs.$0)
-      if (wrap) u = wordwrap(0, wrap)(u)
-      help.unshift(u, '')
+      ui.row({text: u, padding: [0, 0, 1, 0]})
+    }
+
+    // your application's commands, i.e., non-option
+    // arguments populated in '_'.
+    if (commands.length) {
+      ui.row('Commands:')
+
+      // find length of longest command.
+      width = 0
+      commands.forEach(function (command) {
+        width = Math.max(command[0].length, width)
+      })
+
+      commands.forEach(function (command) {
+        ui.row(
+          {text: command[0], padding: [0, 2, 0, 2], width: width + 4},
+          {text: command[1]}
+        )
+      })
+
+      ui.row()
     }
 
     // the options table.
@@ -150,58 +157,65 @@ module.exports = function (yargs) {
       return acc
     }, {})
 
-    var switchTable = {}
-    keys.forEach(function (key) {
-      var kswitch = switches[key]
-      var desc = descriptions[key] || ''
-      var type = null
+    if (keys.length) {
+      ui.row('Options:')
 
-      if (~options.boolean.indexOf(key)) type = '[boolean]'
-      if (~options.count.indexOf(key)) type = '[count]'
-      if (~options.string.indexOf(key)) type = '[string]'
-      if (~options.normalize.indexOf(key)) type = '[string]'
-      if (~options.array.indexOf(key)) type = '[array]'
+      // find length of longest switch.
+      width = 0
+      keys.forEach(function (key) {
+        width = Math.max(switches[key].length, width)
+      })
 
-      var extra = [
-        type,
-        demanded[key] ? '[required]' : null,
-        defaultString(options.default[key], options.defaultDescription[key])
-      ].filter(Boolean).join('  ')
+      keys.forEach(function (key) {
+        var kswitch = switches[key]
+        var desc = descriptions[key] || ''
+        var type = null
 
-      switchTable[kswitch] = {
-        desc: desc,
-        extra: extra
-      }
-    })
-    help.push.apply(help, formatTable(switchTable, 3))
+        if (~options.boolean.indexOf(key)) type = '[boolean]'
+        if (~options.count.indexOf(key)) type = '[count]'
+        if (~options.string.indexOf(key)) type = '[string]'
+        if (~options.normalize.indexOf(key)) type = '[string]'
+        if (~options.array.indexOf(key)) type = '[array]'
 
-    if (keys.length) help.push('')
+        var extra = [
+          type,
+          demanded[key] ? '[required]' : null,
+          defaultString(options.default[key], options.defaultDescription[key])
+        ].filter(Boolean).join(' ')
+
+        ui.row(
+          {text: kswitch, padding: [0, 2, 0, 2], width: Math.min(width + 4, parseInt(wrap * 0.3, 10))},
+          desc
+        )
+
+        if (extra) ui.row({text: extra, padding: [0, 0, 0, width + 4], align: 'right'})
+      })
+
+      ui.row()
+    }
 
     // describe some common use-cases for your application.
     if (examples.length) {
+      ui.row('Examples:')
+
       examples.forEach(function (example) {
         example[0] = example[0].replace(/\$0/g, yargs.$0)
+        ui.row(
+          {text: example[0], padding: [0, 2, 0, 2]},
+          example[1]
+        )
       })
 
-      var examplesTable = {}
-      examples.forEach(function (example) {
-        examplesTable[example[0]] = {
-          desc: example[1],
-          extra: ''
-        }
-      })
-
-      help.push.apply(help, ['Examples:'].concat(formatTable(examplesTable, 5), ''))
+      ui.row()
     }
 
     // the usage string.
     if (epilog) {
       var e = epilog.replace(/\$0/g, yargs.$0)
-      if (wrap) e = wordwrap(0, wrap)(e)
-      help.push(e, '')
+      ui.row({text: e, padding: [0, 0, 1, 0]})
     }
 
-    return help.join('\n')
+    return ui.toString()
   }
 
   // make sure any options set for aliases,
@@ -265,121 +279,13 @@ module.exports = function (yargs) {
     return string + ']'
   }
 
-  // word-wrapped two-column layout used by
-  // examples, options, commands.
-  function formatTable (table, padding) {
-    var output = []
-
-    // size of left-hand-column.
-    var llen = longest(Object.keys(table))
-
-    // don't allow the left-column to take up
-    // more than half of the screen.
-    if (wrap) {
-      llen = Math.min(llen, parseInt(wrap / 2, 10))
-    }
-
-    // size of right-column.
-    var desclen = longest(Object.keys(table).map(function (k) {
-      return table[k].desc
-    }))
-
-    Object.keys(table).forEach(function (left) {
-      var desc = table[left].desc,
-        extra = table[left].extra,
-        leftLines = null
-
-      if (wrap) {
-        desc = wordwrap(llen + padding + 1, wrap)(desc)
-        .slice(llen + padding + 1)
-      }
-
-      // if we need to wrap the left-hand-column,
-      // split it on to multiple lines.
-      if (wrap && left.length > llen) {
-        leftLines = wordwrap(2, llen)(left.trim()).split('\n')
-        left = ''
-      }
-
-      var lpadding = new Array(
-        Math.max(llen - left.length + padding, 0)
-      ).join(' ')
-
-      var dpadding = new Array(
-        Math.max(desclen - desc.length + 1, 0)
-      ).join(' ')
-
-      if (!wrap && dpadding.length > 0) {
-        desc += dpadding
-      }
-
-      var prelude = '  ' + left + lpadding
-
-      var body = [ desc, extra ].filter(Boolean).join('  ')
-
-      if (wrap) {
-        var dlines = desc.split('\n')
-        var dlen = dlines.slice(-1)[0].length
-        + (dlines.length === 1 ? prelude.length : 0)
-
-        if (extra.length > wrap) {
-          body = desc + '\n' + wordwrap(llen + 4, wrap)(extra)
-        } else {
-          body = desc + (dlen + extra.length > wrap - 2
-            ? '\n'
-            + new Array(wrap - extra.length + 1).join(' ')
-            + extra
-            : new Array(wrap - extra.length - dlen + 1).join(' ')
-            + extra
-          )
-        }
-      }
-
-      if (leftLines) { // handle word-wrapping the left-hand-column.
-        var rightLines = body.split('\n'),
-          firstLine = prelude + rightLines[0],
-          lineCount = Math.max(leftLines.length, rightLines.length)
-
-        for (var i = 0; i < lineCount; i++) {
-          var l = leftLines[i],
-            r = i ? rightLines[i] : firstLine
-
-          output.push(strcpy(l, r, firstLine.length))
-        }
-      } else {
-        output.push(prelude + body)
-      }
-    })
-
-    return output
-  }
-
   // find longest string in array of strings.
-  function longest (xs) {
+  /*function longest (xs) {
     return Math.max.apply(
       null,
       xs.map(function (x) { return x.length })
     )
-  }
-
-  // copy one string into another, used when
-  // formatting usage table.
-  function strcpy (source, destination, width) {
-    var str = ''
-
-    source = source || ''
-    destination = destination || new Array(width).join(' ')
-
-    for (var i = 0; i < destination.length; i++) {
-      var char = destination.charAt(i)
-
-      if (char === ' ') char = source.charAt(i) || char
-
-      str += char
-    }
-
-    return str
-  }
+  }*/
 
   // guess the width of the console window, max-width 100.
   function windowWidth () {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   ],
   "dependencies": {
     "camelcase": "^1.0.2",
+    "cliui": "^1.4.0",
     "decamelize": "^1.0.0",
-    "window-size": "0.1.0",
-    "wordwrap": "0.0.2"
+    "window-size": "0.1.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "camelcase": "^1.0.2",
-    "cliui": "^1.4.0",
+    "cliui": "^2.0.0",
     "decamelize": "^1.0.0",
     "window-size": "0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "camelcase": "^1.0.2",
-    "cliui": "^2.0.0",
+    "cliui": "^2.1.0",
     "decamelize": "^1.0.0",
     "window-size": "0.1.0"
   },

--- a/test/usage.js
+++ b/test/usage.js
@@ -881,7 +881,7 @@ describe('usage tests', function () {
       })
 
       // should split example usage onto multiple lines.
-      r.errors[0].split('\n').length.should.equal(10)
+      r.errors[0].split('\n').length.should.equal(8)
 
       // should wrap within appropriate boundaries.
       r.errors[0].split('\n').forEach(function (line, i) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -24,10 +24,8 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -x NUM -y NUM',
           'Options:',
-          '  -x',
-          '      [required]',
-          '  -y',
-          '      [required]',
+          '  -x  [required]',
+          '  -y  [required]',
           'Missing required arguments: y'
         ])
         r.logs.should.have.length(0)
@@ -49,10 +47,8 @@ describe('usage tests', function () {
           r.errors.join('\n').split(/\n+/).should.deep.equal([
             'Usage: ./usage -x NUM -y NUM',
             'Options:',
-            '  -x',
-            '      [required]',
-            '  -y',
-            '      [required]',
+            '  -x  [required]',
+            '  -y  [required]',
             'Missing required arguments: y'
           ])
           r.logs.should.have.length(0)
@@ -74,10 +70,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage -x NUM -y NUM',
         'Options:',
-        '  -x',
-        '      [required]',
-        '  -y',
-        '      [required]',
+        '  -x  [required]',
+        '  -y  [required]',
         'Missing required arguments: x, y',
         'x and y are both required to multiply all the things'
       ])
@@ -325,8 +319,7 @@ describe('usage tests', function () {
     })
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
-      '  -f, --foo',
-      '             [default: 5]',
+      '  -f, --foo  [default: 5]',
       'Not enough non-option arguments: got 0, need at least 1'
     ])
   })
@@ -471,10 +464,8 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage [options]',
         'Options:',
-        '  --foo, -f',
-        '             [required]',
-        '  --bar, -b',
-        '             [required]',
+        '  --foo, -f  [required]',
+        '  --bar, -b  [required]',
         'Unknown argument: baz'
       ])
       r.should.have.property('logs').with.length(0)
@@ -587,10 +578,9 @@ describe('usage tests', function () {
     r.should.have.property('exit').and.be.ok
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
-      '  -y',
-      '      [required]',
+      '  -y  [required]',
       'Examples:',
-      '  ./usage something  description',
+      '  ./usage something       description',
       '  ./usage something else  other description',
       'Missing required arguments: y'
     ])
@@ -616,8 +606,7 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option',
-          '      [required]',
+          '  -x  an option  [required]',
           '  -y  another option',
           '',
           'Missing required arguments: x'
@@ -646,8 +635,7 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option',
-          '      [required]',
+          '  -x  an option  [required]',
           '  -y  another option',
           '',
           'Missing required arguments: x'
@@ -692,8 +680,7 @@ describe('usage tests', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --help  Show help',
-        '  -y',
-        '          [required]',
+        '  -y  [required]',
         ''
       ])
     })
@@ -716,9 +703,8 @@ describe('usage tests', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage options',
         'Options:',
-        '  --help  Show help',
-        '  --some-opt  Some option',
-        '              [default: 2]',
+        '  --help      Show help',
+        '  --some-opt  Some option  [default: 2]',
         ''
       ])
     })
@@ -885,17 +871,17 @@ describe('usage tests', function () {
     it('should wrap the left-hand-column if it takes up more than 50% of the screen', function () {
       var r = checkUsage(function () {
         return yargs([])
-        .example(
-          'i am a fairly long example',
-          'description that is also fairly long'
-        )
-        .demand('foo')
-        .wrap(40)
-        .argv
+          .example(
+            'i am a fairly long example',
+            'description that is also fairly long'
+          )
+          .demand('foo')
+          .wrap(40)
+          .argv
       })
 
       // should split example usage onto multiple lines.
-      r.errors[0].split('\n').length.should.equal(8)
+      r.errors[0].split('\n').length.should.equal(10)
 
       // should wrap within appropriate boundaries.
       r.errors[0].split('\n').forEach(function (line, i) {
@@ -936,8 +922,7 @@ describe('usage tests', function () {
         '  upload    upload something',
         '  download  download something from somewhere',
         'Options:',
-        '  -y',
-        '      [required]',
+        '  -y  [required]',
         'Missing required arguments: y'
       ])
     })
@@ -947,16 +932,15 @@ describe('usage tests', function () {
     it('should display an epilog message at the end of the usage instructions', function () {
       var r = checkUsage(function () {
         return yargs('')
-        .epilog('for more info view the manual at http://example.com')
-        .demand('y')
-        .wrap(null)
-        .argv
+          .epilog('for more info view the manual at http://example.com')
+          .demand('y')
+          .wrap(null)
+          .argv
       })
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -y',
-        '      [required]',
+        '  -y  [required]',
         'for more info view the manual at http://example.com',
         'Missing required arguments: y'
       ])
@@ -965,16 +949,15 @@ describe('usage tests', function () {
     it('replaces $0 in epilog string', function () {
       var r = checkUsage(function () {
         return yargs('')
-        .epilog("Try '$0 --long-help' for more information")
-        .demand('y')
-        .wrap(null)
-        .argv
+          .epilog("Try '$0 --long-help' for more information")
+          .demand('y')
+          .wrap(null)
+          .argv
       })
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -y',
-        '      [required]',
+        '  -y  [required]',
         'Try \'./usage --long-help\' for more information',
         'Missing required arguments: y'
       ])
@@ -1047,16 +1030,16 @@ describe('usage tests', function () {
     it("should display 'description' string in help message if set for alias", function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
-        .describe('foo', 'foo option')
-        .alias('f', 'foo')
-        .help('h')
-        .wrap(null)
-        .argv
+          .describe('foo', 'foo option')
+          .alias('f', 'foo')
+          .help('h')
+          .wrap(null)
+          .argv
       })
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h  Show help',
+        '  -h         Show help',
         '  -f, --foo  foo option',
         ''
       ])
@@ -1074,9 +1057,8 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h  Show help',
-        '  -f, --foo',
-        '             [required]',
+        '  -h         Show help',
+        '  -f, --foo  [required]',
         ''
       ])
     })
@@ -1094,9 +1076,8 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h  Show help',
-        '  -f, --foo  bar',
-        '             [string]',
+        '  -h         Show help',
+        '  -f, --foo  bar  [string]',
         ''
       ])
     })

--- a/test/usage.js
+++ b/test/usage.js
@@ -13,10 +13,10 @@ describe('usage tests', function () {
       it('should show an error along with the missing arguments on demand fail', function () {
         var r = checkUsage(function () {
           return yargs('-x 10 -z 20'.split(' '))
-          .usage('Usage: $0 -x NUM -y NUM')
-          .demand(['x', 'y'])
-          .wrap(null)
-          .argv
+            .usage('Usage: $0 -x NUM -y NUM')
+            .demand(['x', 'y'])
+            .wrap(null)
+            .argv
         })
         r.result.should.have.property('x', 10)
         r.result.should.have.property('z', 20)
@@ -24,8 +24,10 @@ describe('usage tests', function () {
         r.errors.join('\n').split(/\n+/).should.deep.equal([
           'Usage: ./usage -x NUM -y NUM',
           'Options:',
-          '  -x  [required]',
-          '  -y  [required]',
+          '  -x',
+          '      [required]',
+          '  -y',
+          '      [required]',
           'Missing required arguments: y'
         ])
         r.logs.should.have.length(0)
@@ -36,10 +38,10 @@ describe('usage tests', function () {
         it('should show an error along with the missing arguments on demand fail', function () {
           var r = checkUsage(function () {
             return yargs('-x 10 -z 20'.split(' '))
-            .usage('Usage: $0 -x NUM -y NUM')
-            .require(['x', 'y'])
-            .wrap(null)
-            .argv
+              .usage('Usage: $0 -x NUM -y NUM')
+              .require(['x', 'y'])
+              .wrap(null)
+              .argv
           })
           r.result.should.have.property('x', 10)
           r.result.should.have.property('z', 20)
@@ -47,8 +49,10 @@ describe('usage tests', function () {
           r.errors.join('\n').split(/\n+/).should.deep.equal([
             'Usage: ./usage -x NUM -y NUM',
             'Options:',
-            '  -x  [required]',
-            '  -y  [required]',
+            '  -x',
+            '      [required]',
+            '  -y',
+            '      [required]',
             'Missing required arguments: y'
           ])
           r.logs.should.have.length(0)
@@ -70,8 +74,10 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage -x NUM -y NUM',
         'Options:',
-        '  -x  [required]',
-        '  -y  [required]',
+        '  -x',
+        '      [required]',
+        '  -y',
+        '      [required]',
         'Missing required arguments: x, y',
         'x and y are both required to multiply all the things'
       ])
@@ -99,9 +105,10 @@ describe('usage tests', function () {
     it('should not show a custom message if msg is null', function () {
       var r = checkUsage(function () {
         return yargs('')
-        .usage('Usage: foo')
-        .demand(1, null)
-        .argv
+          .usage('Usage: foo')
+          .demand(1, null)
+          .wrap(null)
+          .argv
       })
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
@@ -310,16 +317,16 @@ describe('usage tests', function () {
   it('should print a single line when failing and default is set for an alias', function () {
     var r = checkUsage(function () {
       return yargs('')
-      .alias('f', 'foo')
-      .default('f', 5)
-      .demand(1)
-      .wrap(null)
-      .argv
-
+        .alias('f', 'foo')
+        .default('f', 5)
+        .demand(1)
+        .wrap(null)
+        .argv
     })
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
-      '  -f, --foo  [default: 5]',
+      '  -f, --foo',
+      '             [default: 5]',
       'Not enough non-option arguments: got 0, need at least 1'
     ])
   })
@@ -464,8 +471,10 @@ describe('usage tests', function () {
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage [options]',
         'Options:',
-        '  --foo, -f  [required]',
-        '  --bar, -b  [required]',
+        '  --foo, -f',
+        '             [required]',
+        '  --bar, -b',
+        '             [required]',
         'Unknown argument: baz'
       ])
       r.should.have.property('logs').with.length(0)
@@ -565,11 +574,11 @@ describe('usage tests', function () {
   it('should display example on fail', function () {
     var r = checkUsage(function () {
       return yargs('')
-      .example('$0 something', 'description')
-      .example('$0 something else', 'other description')
-      .demand(['y'])
-      .wrap(null)
-      .argv
+        .example('$0 something', 'description')
+        .example('$0 something else', 'other description')
+        .demand(['y'])
+        .wrap(null)
+        .argv
     })
     r.should.have.property('result')
     r.result.should.have.property('_').with.length(0)
@@ -578,10 +587,11 @@ describe('usage tests', function () {
     r.should.have.property('exit').and.be.ok
     r.errors.join('\n').split(/\n+/).should.deep.equal([
       'Options:',
-      '  -y  [required]',
+      '  -y',
+      '      [required]',
       'Examples:',
-      '  ./usage something         description      ',
-      '  ./usage something else    other description',
+      '  ./usage something  description',
+      '  ./usage something else  other description',
       'Missing required arguments: y'
     ])
   })
@@ -591,13 +601,13 @@ describe('usage tests', function () {
       it('should report missing required arguments', function () {
         var r = checkUsage(function () {
           return yargs('-y 10 -z 20'.split(' '))
-          .usage('Usage: $0 -x NUM [-y NUM]')
-          .options({
-            'x': { description: 'an option', demand: true },
-            'y': { description: 'another option', demand: false }
-          })
-          .wrap(null)
-          .argv
+            .usage('Usage: $0 -x NUM [-y NUM]')
+            .options({
+              'x': { description: 'an option', demand: true },
+              'y': { description: 'another option', demand: false }
+            })
+            .wrap(null)
+            .argv
         })
         r.result.should.have.property('y', 10)
         r.result.should.have.property('z', 20)
@@ -606,7 +616,8 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option       [required]',
+          '  -x  an option',
+          '      [required]',
           '  -y  another option',
           '',
           'Missing required arguments: x'
@@ -620,13 +631,13 @@ describe('usage tests', function () {
       it('should report missing required arguments', function () {
         var r = checkUsage(function () {
           return yargs('-y 10 -z 20'.split(' '))
-          .usage('Usage: $0 -x NUM [-y NUM]')
-          .options({
-            'x': { description: 'an option', required: true },
-            'y': { description: 'another option', required: false }
-          })
-          .wrap(null)
-          .argv
+            .usage('Usage: $0 -x NUM [-y NUM]')
+            .options({
+              'x': { description: 'an option', required: true },
+              'y': { description: 'another option', required: false }
+            })
+            .wrap(null)
+            .argv
         })
         r.result.should.have.property('y', 10)
         r.result.should.have.property('z', 20)
@@ -635,7 +646,8 @@ describe('usage tests', function () {
           'Usage: ./usage -x NUM [-y NUM]',
           '',
           'Options:',
-          '  -x  an option       [required]',
+          '  -x  an option',
+          '      [required]',
           '  -y  another option',
           '',
           'Missing required arguments: x'
@@ -667,10 +679,10 @@ describe('usage tests', function () {
     it('should display usage', function () {
       var r = checkUsage(function () {
         return yargs(['--help'])
-        .demand(['y'])
-        .help('help')
-        .wrap(null)
-        .argv
+          .demand(['y'])
+          .help('help')
+          .wrap(null)
+          .argv
       })
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
@@ -680,7 +692,8 @@ describe('usage tests', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
         '  --help  Show help',
-        '  -y                 [required]',
+        '  -y',
+        '          [required]',
         ''
       ])
     })
@@ -688,12 +701,12 @@ describe('usage tests', function () {
     it('should not show both dashed and camelCase aliases', function () {
       var r = checkUsage(function () {
         return yargs(['--help'])
-        .usage('Usage: $0 options')
-        .help('help')
-        .describe('some-opt', 'Some option')
-        .default('some-opt', 2)
-        .wrap(null)
-        .argv
+          .usage('Usage: $0 options')
+          .help('help')
+          .describe('some-opt', 'Some option')
+          .default('some-opt', 2)
+          .wrap(null)
+          .argv
       })
       r.should.have.property('result')
       r.result.should.have.property('_').with.length(0)
@@ -703,8 +716,9 @@ describe('usage tests', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage options',
         'Options:',
-        '  --help      Show help  ',
-        '  --some-opt  Some option  [default: 2]',
+        '  --help  Show help',
+        '  --some-opt  Some option',
+        '              [default: 2]',
         ''
       ])
     })
@@ -828,14 +842,13 @@ describe('usage tests', function () {
           description: 'npm prefix used to locate globally installed npm packages'
         })
         .demand('foo')
-        .wrap(40)
+        .wrap(50)
         .argv
       })
 
       r.errors[0].split('\n').forEach(function (line, i) {
         if (!i || !line) return // ignore first and last line.
-        line.length.should.gt(30)
-        line.length.should.lte(40)
+        line.length.should.lte(50)
       })
     })
 
@@ -873,8 +886,8 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs([])
         .example(
-          'i am a fairly long example command and should wrap',
-          'description'
+          'i am a fairly long example',
+          'description that is also fairly long'
         )
         .demand('foo')
         .wrap(40)
@@ -882,14 +895,13 @@ describe('usage tests', function () {
       })
 
       // should split example usage onto multiple lines.
-      r.errors[0].split('\n').length.should.equal(9)
+      r.errors[0].split('\n').length.should.equal(8)
 
       // should wrap within appropriate boundaries.
       r.errors[0].split('\n').forEach(function (line, i) {
         // ignore headings and blank lines.
         if (!line || line.match('Examples:') || line.match('Options:')) return
 
-        line.length.should.gt(30)
         line.length.should.lte(40)
       })
     })
@@ -921,10 +933,11 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Commands:',
-        '  upload      upload something                 ',
-        '  download    download something from somewhere',
+        '  upload    upload something',
+        '  download  download something from somewhere',
         'Options:',
-        '  -y  [required]',
+        '  -y',
+        '      [required]',
         'Missing required arguments: y'
       ])
     })
@@ -942,7 +955,8 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -y  [required]',
+        '  -y',
+        '      [required]',
         'for more info view the manual at http://example.com',
         'Missing required arguments: y'
       ])
@@ -959,7 +973,8 @@ describe('usage tests', function () {
 
       r.errors.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -y  [required]',
+        '  -y',
+        '      [required]',
         'Try \'./usage --long-help\' for more information',
         'Missing required arguments: y'
       ])
@@ -1037,12 +1052,11 @@ describe('usage tests', function () {
         .help('h')
         .wrap(null)
         .argv
-
       })
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help ',
+        '  -h  Show help',
         '  -f, --foo  foo option',
         ''
       ])
@@ -1060,8 +1074,9 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help',
-        '  -f, --foo             [required]',
+        '  -h  Show help',
+        '  -f, --foo',
+        '             [required]',
         ''
       ])
     })
@@ -1079,8 +1094,9 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help',
-        '  -f, --foo  bar        [string]',
+        '  -h  Show help',
+        '  -f, --foo  bar',
+        '             [string]',
         ''
       ])
     })


### PR DESCRIPTION
### What Have You Done!

I found the logic in yargs for laying out multi-column tables to be some of the most confusing in the codebase. It had grown fairly organically, and we were doing backflips to use the same code for: `commands`, `examples`, and `options`.

Motivated by this, I've created the library `cliui`:

https://www.npmjs.com/package/cliui

Which provides an abstraction for multi-column UIs.

### Testing Help Please

This is a fairly major change, I've tested the usage output with several of my own yargs applications, but I'd love a second set of eyes.

Mind helping with testing? @annonymouse, @nylen, @pirxpilot, @raine