### PR TITLE
allows a handling function to be associated with a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,18 +501,33 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
-.command(cmd, desc)
+.command(cmd, desc, [fn])
 -------------------
 
-Document the commands exposed by your application (stored in the `_` variable).
+Document the commands exposed by your application.
 
-As an example, here's how the npm cli might document some of its commands:
+use `desc` to provide a description for each command your application accepts (the
+values stored in `argv._`).
+
+Optionally, you can provide a handler `fn` which will be executed when
+a given command is provided. The handler will be executed with an instance
+of `yargs`, which can be used to compose nested commands.
+
+Here's an example of top-level and nested commands in action:
 
 ```js
 var argv = require('yargs')
   .usage('npm <command>')
   .command('install', 'tis a mighty fine package to install')
-  .command('publish', 'shiver me timbers, should you be sharing all that')
+  .command('publish', 'shiver me timbers, should you be sharing all that', function (yargs) {
+    argv = yargs.option('f', {
+      alias: 'force',
+      description: 'yar, it usually be a bad idea'
+    })
+    .help('help')
+    .argv
+  })
+  .help('help')
   .argv;
 ```
 

--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ function Argv (processArgs, cwd) {
     }
 
     // if there's a handler associated with a
-    // command differ processing to it.
+    // command defer processing to it.
     var handlerKeys = Object.keys(self.getCommandHandlers())
     for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
       if (~argv._.indexOf(command)) {

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function Argv (processArgs, cwd) {
     helpOpt = null
     versionOpt = null
     completionOpt = null
+    commandHandlers = {}
 
     return self
   }
@@ -108,9 +109,15 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.command = function (cmd, description) {
+  self.command = function (cmd, description, fn) {
     usage.command(cmd, description)
+    if (fn) commandHandlers[cmd] = fn
     return self
+  }
+
+  var commandHandlers = {}
+  self.getCommandHandlers = function () {
+    return commandHandlers
   }
 
   self.string = function (strings) {
@@ -398,6 +405,16 @@ function Argv (processArgs, cwd) {
       self.showCompletionScript()
       if (exitProcess) {
         process.exit(0)
+      }
+    }
+
+    // if there's a handler associated with a
+    // command differ processing to it.
+    var handlerKeys = Object.keys(self.getCommandHandlers())
+    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
+      if (~argv._.indexOf(command)) {
+        self.getCommandHandlers()[command](self.reset())
+        return
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function Argv (processArgs, cwd) {
     versionOpt = null
     completionOpt = null
     commandHandlers = {}
+    self.parsed = false
 
     return self
   }
@@ -304,6 +305,7 @@ function Argv (processArgs, cwd) {
   self.version = function (ver, opt, msg) {
     versionOpt = opt || 'version'
     usage.version(ver)
+    self.boolean(versionOpt)
     self.describe(versionOpt, msg || 'Show version number')
     return self
   }
@@ -311,6 +313,7 @@ function Argv (processArgs, cwd) {
   var helpOpt = null
   self.addHelpOpt = function (opt, msg) {
     helpOpt = opt
+    self.boolean(opt)
     self.describe(opt, msg || 'Show help')
     return self
   }
@@ -393,8 +396,8 @@ function Argv (processArgs, cwd) {
 
   function parseArgs (args) {
     var parsed = Parser(args, options),
-    argv = parsed.argv,
-    aliases = parsed.aliases
+      argv = parsed.argv,
+      aliases = parsed.aliases
 
     argv.$0 = self.$0
 
@@ -414,17 +417,17 @@ function Argv (processArgs, cwd) {
     for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
       if (~argv._.indexOf(command)) {
         self.getCommandHandlers()[command](self.reset())
-        return
+        return self.argv
       }
     }
 
     Object.keys(argv).forEach(function (key) {
-      if (key === helpOpt) {
+      if (key === helpOpt && argv[key]) {
         self.showHelp('log')
         if (exitProcess) {
           process.exit(0)
         }
-      } else if (key === versionOpt) {
+      } else if (key === versionOpt && argv[key]) {
         usage.showVersion()
         if (exitProcess) {
           process.exit(0)

--- a/test/usage.js
+++ b/test/usage.js
@@ -679,7 +679,7 @@ describe('usage tests', function () {
       r.should.have.property('exit').and.be.ok
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  --help  Show help',
+        '  --help  Show help  [boolean]',
         '  -y  [required]',
         ''
       ])
@@ -703,7 +703,7 @@ describe('usage tests', function () {
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Usage: ./usage options',
         'Options:',
-        '  --help      Show help',
+        '  --help      Show help  [boolean]',
         '  --some-opt  Some option  [default: 2]',
         ''
       ])
@@ -1039,7 +1039,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help',
+        '  -h         Show help  [boolean]',
         '  -f, --foo  foo option',
         ''
       ])
@@ -1057,7 +1057,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help',
+        '  -h         Show help  [boolean]',
         '  -f, --foo  [required]',
         ''
       ])
@@ -1076,7 +1076,7 @@ describe('usage tests', function () {
 
       r.logs.join('\n').split(/\n+/).should.deep.equal([
         'Options:',
-        '  -h         Show help',
+        '  -h         Show help  [boolean]',
         '  -f, --foo  bar  [string]',
         ''
       ])

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -206,6 +206,7 @@ describe('yargs dsl tests', function () {
           .command('blerg', 'handle blerg things', function (yargs) {
             yargs.command('snuh', 'snuh command')
               .help('h')
+              .wrap(null)
               .argv
           })
           .help('h')
@@ -217,7 +218,7 @@ describe('yargs dsl tests', function () {
         '  snuh  snuh command',
         '',
         'Options:',
-        '  -h  Show help',
+        '  -h  Show help  [boolean]',
         ''
       ])
     })
@@ -231,6 +232,7 @@ describe('yargs dsl tests', function () {
               .argv
           })
           .help('h')
+          .wrap(null)
           .argv
       })
 
@@ -239,7 +241,7 @@ describe('yargs dsl tests', function () {
         '  blerg  handle blerg things',
         '',
         'Options:',
-        '  -h  Show help',
+        '  -h  Show help  [boolean]',
         ''
       ])
     })


### PR DESCRIPTION
allows a handling function to be associated with a command see #156 

you can now optionally provide a third argument to `command`, which represents a handler for the function.

This command will get an instance of `yargs` passed into it, which can then be used to parse arguments specific to the command:

```javascript
        yargs(['snuh', '-h'])
          .command('blerg', 'handle blerg things', function (yargs) {
            yargs.command('snuh', 'snuh command')
              .help('h')
              .argv
          })
          .help('h')
          .argv
```

I found that I tend to write boiler-plate code for a lot of my command-line applications, for facilitating this functionality.