### PR TITLE
fixed failing tests, along with a few other tiny patches

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: didtqzHZLWe60ie2OustNiEtouOYy4F88

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 *.swp
 test.js
+coverage
+nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
   - "0.11"
   - "0.12"
   - "iojs"
-after_script: "NODE_ENV=test YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha --require patched-blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
+after_success: npm run coverage
+env:
+  - secure: "U5owYv3F2kT6FdxOhWltfpJbHe3CFxNqDyToDOGyA6a9cyKZQe8LQhBJTFxT606nfWaRuxRrRQ1+/tl4rDMjX3PwzR0MTaE/6cIItqe8jra7M3y7u9fBhM5WRWHs7MOVAeXkacZZ3oha6VugoZaQZQNT5myI3BhsvZKmn8JlciY="

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -106,7 +106,7 @@ module.exports = function (yargs) {
       ),
       ui = cliui({
         width: wrap,
-        wrap: wrap ? true : false
+        wrap: !!wrap
       })
 
     // the usage string.

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
     "chai": "^2.2.0",
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
-    "mocha": "^2.2.1",
-    "mocoverage": "^1.0.0",
-    "standard": "^3.6.0"
+    "mocha": "^2.2.1"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks && nyc report",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "chai": "^2.2.0",
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "nyc": "^2.0.0"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks && nyc report",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
-    "nyc": "^2.0.0"
+    "nyc": "^2.0.0",
+    "standard": "^3.9.0"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks && nyc report",

--- a/package.json
+++ b/package.json
@@ -20,30 +20,16 @@
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
-    "mocha-lcov-reporter": "0.0.2",
     "mocoverage": "^1.0.0",
-    "patched-blanket": "^1.0.1",
     "standard": "^3.6.0"
   },
   "scripts": {
-    "test": "standard && mocha --check-leaks --ui exports --require patched-blanket -R mocoverage"
+    "test": "standard && nyc mocha --check-leaks && nyc report",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
     "url": "http://github.com/bcoe/yargs.git"
-  },
-  "config": {
-    "blanket": {
-      "pattern": [
-        "lib",
-        "index.js"
-      ],
-      "data-cover-never": [
-        "node_modules",
-        "test"
-      ],
-      "output-reporter": "spec"
-    }
   },
   "standard": {
     "ignore": [
@@ -86,6 +72,10 @@
     {
       "name": "Benjamin Horsleben",
       "url": "https://github.com/fizker"
+    },
+    {
+      "name": "Lin Clark",
+      "url": "https://github.com/linclark"
     }
   ],
   "license": "MIT",

--- a/test/parser.js
+++ b/test/parser.js
@@ -956,8 +956,8 @@ describe('parser tests', function () {
 
     it('should raise an exception if there are not enough arguments following key', function () {
       expect(function () {
-        yargs().nargs('foo', 2).
-          parse([ '--foo', 'apple'])
+        yargs().nargs('foo', 2)
+          .parse([ '--foo', 'apple'])
       }).to.throw('not enough arguments following: foo')
     })
 


### PR DESCRIPTION
* fixed the failing tests, related to new standard constraints (@linclark you should rebase with this branch).
* added Lin as a collaborator in package.json.
* switched to [nyc](https://github.com/bcoe/nyc), rather than patched-blanket.
* fixed a security issue where the token for coverage was exposed, token has been regenerated.
