### PR TITLE
more intuitive parsing of array arguments see #162

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules/
 *.swp
 test.js
 coverage
-nyc_output
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ regardless of whether they resemble numbers.
 ----------
 
 Tell the parser to interpret `key` as an array. If `.array('foo')` is set,
-`--foo bar` will be parsed as `['bar']` rather than as `'bar'`.
+`--foo foo bar` will be parsed as `['foo', 'bar']` rather than as `'bar'`.
 
 .nargs(key, count)
 -----------
@@ -618,7 +618,7 @@ Optionally `.nargs()` can take an object of `key`/`narg` pairs.
 .config(key)
 ------------
 
-Tells the parser that if the option specified by `key` is passed in, it 
+Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
 and parsed, and its properties are set as arguments.
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -189,8 +189,10 @@ module.exports = function (args, opts) {
       key = arg.slice(-1)[0]
 
       if (!broken && key !== '-') {
+        // nargs format = '-f a b c'
         if (checkAllAliases(key, opts.narg)) {
           i = eatNargs(i, key, args)
+        // array format = '-f a b c'
         } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
           i = eatArray(i, key, args)
         } else {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -69,7 +69,8 @@ module.exports = function (args, opts) {
       key,
       letters,
       m,
-      next
+      next,
+      value
 
     // -- seperated by =
     if (arg.match(/^--.+=/)) {
@@ -77,7 +78,18 @@ module.exports = function (args, opts) {
       // 'dotall' regex modifier. See:
       // http://stackoverflow.com/a/1068308/13216
       m = arg.match(/^--([^=]+)=([\s\S]*)$/)
-      setArg(m[1], m[2])
+
+      // nargs format = '--f=monkey washing cat'
+      if (checkAllAliases(m[1], opts.narg)) {
+        args.splice(i + 1, m[1], m[2])
+        i = eatNargs(i, m[1], args)
+      // arrays format = '--f=a b c'
+      } else if (checkAllAliases(m[1], flags.arrays) && args.length > i + 1) {
+        args.splice(i + 1, m[1], m[2])
+        i = eatArray(i, m[1], args)
+      } else {
+        setArg(m[1], m[2])
+      }
     } else if (arg.match(/^--no-.+/)) {
       key = arg.match(/^--no-(.+)/)[1]
       setArg(key, false)
@@ -86,8 +98,12 @@ module.exports = function (args, opts) {
     } else if (arg.match(/^--.+/)) {
       key = arg.match(/^--(.+)/)[1]
 
+      // nargs format = '--foo a b c'
       if (checkAllAliases(key, opts.narg)) {
         i = eatNargs(i, key, args)
+      // array format = '--foo a b c'
+      } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
+        i = eatArray(i, key, args)
       } else {
         next = args[i + 1]
 
@@ -130,7 +146,21 @@ module.exports = function (args, opts) {
         next = arg.slice(j + 2)
 
         if (letters[j + 1] && letters[j + 1] === '=') {
-          setArg(letters[j], arg.slice(j + 3))
+          value = arg.slice(j + 3)
+          key = letters[j]
+
+          // nargs format = '-f=monkey washing cat'
+          if (checkAllAliases(letters[j], opts.narg)) {
+            args.splice(i + 1, 0, value)
+            i = eatNargs(i, key, args)
+          // array format = '-f=a b c'
+          } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
+            args.splice(i + 1, 0, value)
+            i = eatArray(i, key, args)
+          } else {
+            setArg(key, value)
+          }
+
           broken = true
           break
         }
@@ -161,6 +191,8 @@ module.exports = function (args, opts) {
       if (!broken && key !== '-') {
         if (checkAllAliases(key, opts.narg)) {
           i = eatNargs(i, key, args)
+        } else if (checkAllAliases(key, flags.arrays) && args.length > i + 1) {
+          i = eatArray(i, key, args)
         } else {
           if (args[i + 1] && !/^(-|--)[^-]/.test(args[i + 1])
           && !checkAllAliases(key, flags.bools)
@@ -205,6 +237,19 @@ module.exports = function (args, opts) {
     }
 
     return (i + toEat)
+  }
+
+  // if an option is an array, eat all non-hyphenated arguments
+  // following it... YUM!
+  // e.g., --foo apple banana cat becomes ["apple", "banana", "cat"]
+  function eatArray (i, key, args) {
+    for (var ii = i + 1; ii < args.length; ii++) {
+      if (/^-/.test(args[ii])) break
+      i = ii
+      setArg(key, args[ii])
+    }
+
+    return i
   }
 
   function setArg (key, val) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "coveralls": "^2.11.2",
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
-    "nyc": "^2.0.0",
-    "standard": "^3.9.0"
+    "nyc": "^2.2.1",
+    "standard": "^3.11.1"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks && nyc report",

--- a/test/parser.js
+++ b/test/parser.js
@@ -942,6 +942,34 @@ describe('parser tests', function () {
       Array.isArray(result.caPath).should.equal(true)
       Array.isArray(result.c).should.equal(true)
     })
+
+    // see: https://github.com/bcoe/yargs/issues/162
+    it('should eat non-hyphenated arguments until hyphenated option is hit', function () {
+      var result = yargs()
+        .option('a', {array: true})
+        .option('b', {array: true})
+        .option('foo', {array: true})
+        .option('bar', {array: true})
+        .parse(['-a=hello', 'world', '-b',
+          '33', '22', '--foo', 'red', 'green',
+          '--bar=cat', 'dog'])
+
+      Array.isArray(result.a).should.equal(true)
+      result.a.should.include('hello')
+      result.a.should.include('world')
+
+      Array.isArray(result.b).should.equal(true)
+      result.b.should.include(33)
+      result.b.should.include(22)
+
+      Array.isArray(result.foo).should.equal(true)
+      result.foo.should.include('red')
+      result.foo.should.include('green')
+
+      Array.isArray(result.bar).should.equal(true)
+      result.bar.should.include('cat')
+      result.bar.should.include('dog')
+    })
   })
 
   describe('nargs', function () {
@@ -980,6 +1008,25 @@ describe('parser tests', function () {
       result.f[0].should.equal('apple')
       result.f[1].should.equal('bar')
       result._[0].should.equal('blerg')
+    })
+
+    it('should support nargs for -f= and --bar= format arguments', function () {
+      var result = yargs()
+        .option('f', {
+          nargs: 2
+        })
+        .option('bar', {
+          nargs: 2
+        })
+        .parse([ '-f=apple', 'bar', 'blerg', '--bar=monkey', 'washing', 'cat'])
+
+      result.f[0].should.equal('apple')
+      result.f[1].should.equal('bar')
+      result._[0].should.equal('blerg')
+
+      result.bar[0].should.equal('monkey')
+      result.bar[1].should.equal('washing')
+      result._[1].should.equal('cat')
     })
 
     it('allows multiple nargs to be set at the same time', function () {


### PR DESCRIPTION
This pull request adds more intuitive parsing of array arguments, based on a discussion with @getify (see #162). Here's how things work now:

`--foo a b c` where `foo` is an array, will now be parsed as `['a', 'b', 'c']`.

This pull request includes fixes for both `array` and `nargs`, adding support for `--foo=a b c`.

 