### PR TITLE
expose the method yargs.terminalWidth()

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ Optionally `.nargs()` can take an object of `key`/`narg` pairs.
 .config(key)
 ------------
 
-Tells the parser that if the option specified by `key` is passed in, it 
+Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
 and parsed, and its properties are set as arguments.
 
@@ -629,6 +629,9 @@ Format usage output to wrap at `columns` many columns.
 
 By default wrap will be set to `Math.min(80, windowWidth)`. Use `.wrap(null)` to
 specify no column limit.
+
+`yargs.wrap(yargs.terminalWidth())` can be used to maximize the width
+of yargs' usage instructions.
 
 .strict()
 ---------

--- a/index.js
+++ b/index.js
@@ -379,6 +379,10 @@ function Argv (processArgs, cwd) {
     return validation
   }
 
+  self.terminalWidth = function () {
+    return require('window-size').width
+  }
+
   Object.defineProperty(self, 'argv', {
     get: function () {
       var args = null

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -246,4 +246,10 @@ describe('yargs dsl tests', function () {
       ])
     })
   })
+
+  describe('terminalWidth', function () {
+    it('returns the maximum width of the terminal', function () {
+      yargs.terminalWidth().should.be.gt(0)
+    })
+  })
 })


### PR DESCRIPTION
The terminal width is now exposed by `yargs.terminalWidth()`, this can be used along with `wrap()` to maximize the width of usage instructions.

fixes #155 