### PR TITLE
Avoid help, version, validation, and the completion command while handling the completion option

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,8 +229,8 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.parse = function (args) {
-    return parseArgs(args)
+  self.parse = function (args, skipValidation) {
+    return parseArgs(args, skipValidation)
   }
 
   self.option = self.options = function (key, opt) {
@@ -399,7 +399,7 @@ function Argv (processArgs, cwd) {
     enumerable: true
   })
 
-  function parseArgs (args) {
+  function parseArgs (args, skipValidation) {
     var parsed = Parser(args, options)
     var argv = parsed.argv
     var aliases = parsed.aliases
@@ -452,6 +452,10 @@ function Argv (processArgs, cwd) {
         return
       }
     })
+
+    if (skipValidation) {
+      return argv
+    }
 
     validation.nonOptionCount(argv)
     validation.missingArgumentValue(argv)

--- a/index.js
+++ b/index.js
@@ -408,6 +408,26 @@ function Argv (processArgs, cwd) {
 
     self.parsed = parsed
 
+    if (parseOnly) {
+      return argv
+    }
+
+    // process completion option before all others
+    if (completionOpt in argv) {
+      // we allow for asynchronous completions,
+      // e.g., loading in a list of commands from an API.
+      completion.getCompletion(function (completions) {
+        ;(completions || []).forEach(function (completion) {
+          console.log(completion)
+        })
+
+        if (exitProcess) {
+          process.exit(0)
+        }
+      })
+      return argv
+    }
+
     // generate a completion script for adding to ~/.bashrc.
     if (completionCommand && ~argv._.indexOf(completionCommand)) {
       self.showCompletionScript()
@@ -424,25 +444,6 @@ function Argv (processArgs, cwd) {
         self.getCommandHandlers()[command](self.reset())
         return self.argv
       }
-    }
-
-    if (completionOpt in argv) {
-      // we allow for asynchronous completions,
-      // e.g., loading in a list of commands from an API.
-      completion.getCompletion(function (completions) {
-        ;(completions || []).forEach(function (completion) {
-          console.log(completion)
-        })
-
-        if (exitProcess) {
-          process.exit(0)
-        }
-      })
-      return argv
-    }
-
-    if (parseOnly) {
-      return argv
     }
 
     if (argv[helpOpt]) {

--- a/index.js
+++ b/index.js
@@ -229,8 +229,8 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.parse = function (args, skipValidation) {
-    return parseArgs(args, skipValidation)
+  self.parse = function (args, parseOnly) {
+    return parseArgs(args, parseOnly)
   }
 
   self.option = self.options = function (key, opt) {
@@ -399,7 +399,7 @@ function Argv (processArgs, cwd) {
     enumerable: true
   })
 
-  function parseArgs (args, skipValidation) {
+  function parseArgs (args, parseOnly) {
     var parsed = Parser(args, options)
     var argv = parsed.argv
     var aliases = parsed.aliases
@@ -426,35 +426,37 @@ function Argv (processArgs, cwd) {
       }
     }
 
-    Object.keys(argv).forEach(function (key) {
-      if (key === helpOpt && argv[key]) {
-        self.showHelp('log')
-        if (exitProcess) {
-          process.exit(0)
-        }
-      } else if (key === versionOpt && argv[key]) {
-        usage.showVersion()
-        if (exitProcess) {
-          process.exit(0)
-        }
-      } else if (key === completionOpt) {
-        // we allow for asynchronous completions,
-        // e.g., loading in a list of commands from an API.
-        completion.getCompletion(function (completions) {
-          ;(completions || []).forEach(function (completion) {
-            console.log(completion)
-          })
-
-          if (exitProcess) {
-            process.exit(0)
-          }
+    if (completionOpt in argv) {
+      // we allow for asynchronous completions,
+      // e.g., loading in a list of commands from an API.
+      completion.getCompletion(function (completions) {
+        ;(completions || []).forEach(function (completion) {
+          console.log(completion)
         })
-        return
-      }
-    })
 
-    if (skipValidation) {
+        if (exitProcess) {
+          process.exit(0)
+        }
+      })
       return argv
+    }
+
+    if (parseOnly) {
+      return argv
+    }
+
+    if (argv[helpOpt]) {
+      self.showHelp('log')
+      if (exitProcess) {
+        process.exit(0)
+      }
+    }
+
+    if (argv[versionOpt]) {
+      usage.showVersion()
+      if (exitProcess) {
+        process.exit(0)
+      }
     }
 
     validation.nonOptionCount(argv)

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -13,7 +13,7 @@ module.exports = function (yargs, usage) {
     var completions = []
     var current = process.argv[process.argv.length - 1]
     var previous = process.argv.slice(process.argv.indexOf('--' + self.completionKey) + 1)
-    var argv = yargs.parse(previous)
+    var argv = yargs.parse(previous, true)
 
     // a custom completion function can be provided
     // to completion().

--- a/test/completion.js
+++ b/test/completion.js
@@ -56,6 +56,18 @@ describe('Completion', function () {
       r.errors.should.be.empty
       r.logs.should.include('--foo')
     })
+
+    it('does not execute the completion command while processing the option', function () {
+      var r = checkUsage(function () {
+        return yargs(['--get-yargs-completions'])
+        .completion('completion')
+        .argv
+      }, ['./usage', '--get-yargs-completions', 'completion'])
+
+      // confirm that the completion script is not logged
+      r.logs.should.deep.equal(['completion'])
+    })
+
   })
 
   describe('generateCompletionScript()', function () {

--- a/test/completion.js
+++ b/test/completion.js
@@ -40,6 +40,22 @@ describe('Completion', function () {
       r.logs.should.include('--foo')
       r.logs.should.not.include('bar')
     })
+
+    it('works for strict parsing if next is not yet an option', function () {
+      var r = checkUsage(function () {
+        return yargs(['--get-yargs-completions'])
+        .option('foo', {
+          describe: 'foo option'
+        })
+        .command('bar', 'bar command')
+        .strict()
+        .completion('completion')
+        .argv
+      }, ['./usage', '--get-yargs-completions', '--f'])
+
+      r.errors.should.be.empty
+      r.logs.should.include('--foo')
+    })
   })
 
   describe('generateCompletionScript()', function () {

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -17,8 +17,16 @@ exports.checkOutput = function (f, argv) {
   var errors = []
   var logs = []
 
-  console.error = function (msg) { errors.push(msg) }
-  console.log = function (msg) { logs.push(msg) }
+  console.error = function (msg) {
+    if (!exit) {
+      errors.push(msg)
+    }
+  }
+  console.log = function (msg) {
+    if (!exit) {
+      logs.push(msg)
+    }
+  }
 
   var result = f()
 


### PR DESCRIPTION
While handling the completion option, `parseArgs` is called with a "partial" set of arguments.  With strict parsing, these partial arguments may cause the task to exit with an error.  This screws up completion.  See #177 for an example script.

The changes here add a `parseOnly` argument to the `parse` method.  While the completion values are being determined, `yargs.parse(args, true)` is called to avoid validation.  This allows people to complete options whose partial values may not be valid options.

The test helper needed to be updated so that logging doesn't continue after `process.exit()` has been called.  While processing the `--get-yargs-completions` option in the tests, the call to `process.exit()` doesn't stop execution, and errors were being logged about `get-yargs-completions` being an unknown argument.  To make an assertion about there being no logged errors in the tests, the helper stops errors from being logged after `process.exit()` has been called.

Fixes #177.
Fixes #179.