### PR TITLE
patches for completion, brought about by #177

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,22 +437,20 @@ function Argv (processArgs, cwd) {
 
     // we must run completions first, a user might
     // want to complete the --help or --version option.
-    Object.keys(argv).forEach(function (key) {
-      if (key === completionOpt) {
-        // we allow for asynchronous completions,
-        // e.g., loading in a list of commands from an API.
-        completion.getCompletion(function (completions) {
-          ;(completions || []).forEach(function (completion) {
-            console.log(completion)
-          })
-
-          if (exitProcess) {
-            process.exit(0)
-          }
+    if (completionOpt in argv) {
+      // we allow for asynchronous completions,
+      // e.g., loading in a list of commands from an API.
+      completion.getCompletion(function (completions) {
+        ;(completions || []).forEach(function (completion) {
+          console.log(completion)
         })
-        return
-      }
-    })
+
+        if (exitProcess) {
+          process.exit(0)
+        }
+      })
+      return
+    }
 
     Object.keys(argv).forEach(function (key) {
       if (key === helpOpt && argv[key]) {

--- a/test/completion.js
+++ b/test/completion.js
@@ -115,4 +115,22 @@ describe('Completion', function () {
       .argv
     })
   })
+
+  // fixes for #177.
+  it('does not apply validation when --get-yargs-completions is passed in', function () {
+    var r = checkUsage(function () {
+      try {
+        return yargs(['--get-yargs-completions'])
+          .option('foo', {})
+          .completion()
+          .strict()
+          .argv
+      } catch (e) {
+        console.log(e.message)
+      }
+    }, ['./completion', '--get-yargs-completions', '--'])
+
+    r.errors.length.should.equal(0)
+    r.logs.should.include('--foo')
+  })
 })

--- a/test/fixtures/bin.js
+++ b/test/fixtures/bin.js
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
-var argv = require('../../index').argv
+var argv = require('../../index')
+  .help('help')
+  .completion()
+  .argv
 console.log(JSON.stringify(argv._))

--- a/test/integration.js
+++ b/test/integration.js
@@ -40,6 +40,14 @@ describe('integration tests', function () {
 
   })
 
+  // see #177
+  it('allows --help to be completed without returning help message', function (done) {
+    testCmd('./bin.js', [ '--get-yargs-completions', '--help' ], function (buf) {
+      buf.should.not.match(/generate bash completion script/)
+      buf.should.match(/--help/)
+      return done()
+    })
+  })
 })
 
 function testCmd (cmd, args, done) {
@@ -54,6 +62,9 @@ function testCmd (cmd, args, done) {
   bin.stderr.on('data', done)
 
   bin.stdout.on('data', function (buf) {
+    // hack to allow us to assert against completion suggestions.
+    if (~args.indexOf('--get-yargs-completions')) return done(buf.toString())
+
     var _ = JSON.parse(buf.toString())
     _.map(String).should.deep.equal(args.map(String))
     done()


### PR DESCRIPTION
patches for completion brought about by #177:

* there were problems with completing the completion argument itself, related to it attempting to print out the completion script.
* there were problems completing `--help`, caused by the help output firing.
* there were problems related to strict argument parsing, because `--get-yargs-completions` was not whitelisted.