### PR TITLE
you can now specify a min/max # of non-option arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,17 +398,20 @@ displaying the value in the usage instructions:
 ```
 
 .demand(key, [msg | boolean])
------------------------------
+------------------------------
 .require(key, [msg | boolean])
 ------------------------------
 .required(key, [msg | boolean])
--------------------------------
+------------------------------
+.demand(count, [max], [msg])
+------------------------------
 
 If `key` is a string, show the usage information and exit if `key` wasn't
 specified in `process.argv`.
 
 If `key` is a number, demand at least as many non-option arguments, which show
-up in `argv._`.
+up in `argv._`. A second number can also optionally be provided, which indicates
+the maximum number of non-option arguments.
 
 If `key` is an Array, demand each element.
 

--- a/index.js
+++ b/index.js
@@ -160,10 +160,18 @@ function Argv (processArgs, cwd) {
   }
 
   var demanded = {}
-  self.demand = self.required = self.require = function (keys, msg) {
+  self.demand = self.required = self.require = function (keys, max, msg) {
+    // you can optionally provide a 'max' key,
+    // which will raise an exception if too many '_'
+    // options are provided.
+    if (typeof max !== 'number') {
+      msg = max
+      max = Infinity
+    }
+
     if (typeof keys === 'number') {
-      if (!demanded._) demanded._ = { count: 0, msg: null }
-      demanded._.count += keys
+      if (!demanded._) demanded._ = { count: 0, msg: null, max: max }
+      demanded._.count = keys
       demanded._.msg = msg
     } else if (Array.isArray(keys)) {
       keys.forEach(function (key) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -7,13 +7,18 @@ module.exports = function (yargs, usage) {
   // arguments were provided, i.e., '_'.
   self.nonOptionCount = function (argv) {
     var demanded = yargs.getDemanded()
+    var _s = argv._.length
 
-    if (demanded._ && argv._.length < demanded._.count) {
+    if (demanded._ && (_s < demanded._.count || _s > demanded._.max)) {
       if (demanded._.msg !== undefined) {
         usage.fail(demanded._.msg)
-      } else {
+      } else if (_s < demanded._.count) {
         usage.fail('Not enough non-option arguments: got ' +
           argv._.length + ', need at least ' + demanded._.count
+        )
+      } else {
+        usage.fail('Too many non-option arguments: got ' +
+          argv._.length + ', maximum of ' + demanded._.max
         )
       }
     }


### PR DESCRIPTION
You can now specify a min/max # of non-option arguments, see #169.

It works like so:

```js
yargs.demand(min, max)
```

Where min/max represent the minimum and maximum # of arguments that must be provided.