### PR TITLE
Avoid completing already provided commands

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -31,7 +31,9 @@ module.exports = function (yargs, usage) {
 
     if (!current.match(/^-/)) {
       usage.getCommands().forEach(function (command) {
-        completions.push(command[0])
+        if (previous.indexOf(command[0]) === -1) {
+          completions.push(command[0])
+        }
       })
     }
 

--- a/test/completion.js
+++ b/test/completion.js
@@ -26,6 +26,23 @@ describe('Completion', function () {
       r.logs.should.include('foo')
     })
 
+    it('avoids repeating already included commands', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('foo', 'bar')
+          .command('apple', 'banana')
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'apple'])
+
+      r.logs.should.include('foo')
+      r.logs.should.not.include('apple')
+    })
+
     it("returns arguments as completion suggestion, if next contains '-'", function () {
       var r = checkUsage(function () {
         return yargs(['--get-yargs-completions'])


### PR DESCRIPTION
This makes it so a command that is already in the provided arguments will not be one of the suggested completions.  Since yargs doesn't represent commands more than once in the parsed `argv`, I assume this is non-controversial.

However, this does mean that if a program supports both `foo` and `foobar` as commands, typing `program foo[TAB]` would complete to `foobar`.  I could add some additional logic so that both `foo` and `foobar` were suggested completions in this case.  @bcoe would you be interested in support for this?
