### PR TITLE
Enable completion of options for commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,16 +433,6 @@ function Argv (processArgs, cwd) {
       }
     }
 
-    // if there's a handler associated with a
-    // command defer processing to it.
-    var handlerKeys = Object.keys(self.getCommandHandlers())
-    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
-      if (~argv._.indexOf(command)) {
-        self.getCommandHandlers()[command](self.reset())
-        return self.argv
-      }
-    }
-
     // we must run completions first, a user might
     // want to complete the --help or --version option.
     if (completionOpt in argv) {
@@ -458,6 +448,16 @@ function Argv (processArgs, cwd) {
         }
       })
       return
+    }
+
+    // if there's a handler associated with a
+    // command defer processing to it.
+    var handlerKeys = Object.keys(self.getCommandHandlers())
+    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
+      if (~argv._.indexOf(command)) {
+        self.getCommandHandlers()[command](self.reset())
+        return self.argv
+      }
     }
 
     Object.keys(argv).forEach(function (key) {

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -29,6 +29,13 @@ module.exports = function (yargs, usage) {
       }
     }
 
+    var handlers = yargs.getCommandHandlers()
+    for (var i = 0, ii = previous.length; i < ii; ++i) {
+      if (handlers[previous[i]]) {
+        return handlers[previous[i]](yargs.reset())
+      }
+    }
+
     if (!current.match(/^-/)) {
       usage.getCommands().forEach(function (command) {
         if (previous.indexOf(command[0]) === -1) {

--- a/test/completion.js
+++ b/test/completion.js
@@ -43,6 +43,82 @@ describe('Completion', function () {
       r.logs.should.not.include('apple')
     })
 
+    it('completes options for a command', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('foo', 'foo command', function (subYargs) {
+            subYargs.options({
+              bar: {
+                describe: 'bar option'
+              }
+            })
+            .help('help')
+            .completion()
+            .argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
+
+      r.logs.should.have.length(2)
+      r.logs.should.include('--bar')
+      r.logs.should.include('--help')
+    })
+
+    it('completes options for the correct command', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('cmd1', 'first command', function (subYargs) {
+            subYargs.options({
+              opt1: {
+                describe: 'first option'
+              }
+            })
+            .completion()
+            .argv
+          })
+          .command('cmd2', 'second command', function (subYargs) {
+            subYargs.options({
+              opt2: {
+                describe: 'second option'
+              }
+            })
+            .completion()
+            .argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'cmd2', '--o'])
+
+      r.logs.should.have.length(1)
+      r.logs.should.include('--opt2')
+    })
+
+    it('works if command has no options', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('foo', 'foo command', function (subYargs) {
+            subYargs.completion().argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
+
+      r.logs.should.have.length(0)
+    })
+
     it("returns arguments as completion suggestion, if next contains '-'", function () {
       var r = checkUsage(function () {
         return yargs(['--get-yargs-completions'])


### PR DESCRIPTION
This allows options for commands to be completed.  It requires that a command is configured using `completion`.  E.g.

```js
#!/usr/bin/env node
var argv = require('yargs')
  .completion()
  .command('foo', 'foo command', function(yargs) {
    var sub = yargs
      .completion()
      .option('bar', 'bar option')
      .argv;
  })
  .argv;
```

It does not allow for completion of options for nested commands.  This would be possible, but I'm pretty sure it would involve modification of `process.argv` while processing the `--get-yargs-completions` options.  Not too bad, but this is a pretty simple change and may handle most use cases.

Fixes #180.
