### PR TITLE
Default to filename completion if no other matches are found

### DIFF
--- a/completion.sh.hbs
+++ b/completion.sh.hbs
@@ -16,6 +16,12 @@ _yargs_completions()
     type_list=`{{app_path}} --get-yargs-completions $args`
 
     COMPREPLY=( $(compgen -W "${type_list}" -- ${cur_word}) )
+
+    # if no match was found, fall back to filename completion
+    if [ ${#COMPREPLY[@]} -eq 0 ]; then
+      COMPREPLY=( $(compgen -f "${cur_word}" ) )
+    fi
+
     return 0
 }
 complete -F _yargs_completions {{app_name}}

--- a/completion.sh.hbs
+++ b/completion.sh.hbs
@@ -19,7 +19,7 @@ _yargs_completions()
 
     # if no match was found, fall back to filename completion
     if [ ${#COMPREPLY[@]} -eq 0 ]; then
-      COMPREPLY=( $(compgen -f "${cur_word}" ) )
+      COMPREPLY=( $(compgen -f -- "${cur_word}" ) )
     fi
 
     return 0


### PR DESCRIPTION
If calling a script with `--get-yargs-completions` doesn't result in any matches for the current word, we can fall back to the default filename completion.

See suggestion in https://github.com/bcoe/yargs/issues/180#issuecomment-113799086.