### PR TITLE
a couple minor tweaks to the command-specific completion logic in #185

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,16 +433,6 @@ function Argv (processArgs, cwd) {
       }
     }
 
-    // if there's a handler associated with a
-    // command defer processing to it.
-    var handlerKeys = Object.keys(self.getCommandHandlers())
-    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
-      if (~argv._.indexOf(command)) {
-        self.getCommandHandlers()[command](self.reset())
-        return self.argv
-      }
-    }
-
     // we must run completions first, a user might
     // want to complete the --help or --version option.
     if (completionOpt in argv) {
@@ -458,6 +448,16 @@ function Argv (processArgs, cwd) {
         }
       })
       return
+    }
+
+    // if there's a handler associated with a
+    // command defer processing to it.
+    var handlerKeys = Object.keys(self.getCommandHandlers())
+    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
+      if (~argv._.indexOf(command)) {
+        self.getCommandHandlers()[command](self.reset())
+        return self.argv
+      }
     }
 
     Object.keys(argv).forEach(function (key) {

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -29,6 +29,13 @@ module.exports = function (yargs, usage) {
       }
     }
 
+    var handlers = yargs.getCommandHandlers()
+    for (var i = 0, ii = previous.length; i < ii; ++i) {
+      if (handlers[previous[i]]) {
+        return handlers[previous[i]](yargs.reset())
+      }
+    }
+
     if (!current.match(/^-/)) {
       usage.getCommands().forEach(function (command) {
         if (previous.indexOf(command[0]) === -1) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
     "nyc": "^2.2.1",
-    "standard": "^4.2.1"
+    "standard": "^4.3.2"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks && nyc report",

--- a/test/completion.js
+++ b/test/completion.js
@@ -1,7 +1,8 @@
 /* global describe, it, beforeEach */
-
 var checkUsage = require('./helpers/utils').checkOutput
 var yargs = require('../')
+
+require('chai').should()
 
 describe('Completion', function () {
   beforeEach(function () {
@@ -11,15 +12,11 @@ describe('Completion', function () {
   describe('default completion behavior', function () {
     it('it returns a list of commands as completion suggestions', function () {
       var r = checkUsage(function () {
-        try {
-          return yargs(['--get-yargs-completions'])
+        return yargs(['--get-yargs-completions'])
           .command('foo', 'bar')
           .command('apple', 'banana')
           .completion()
           .argv
-        } catch (e) {
-          console.log(e.message)
-        }
       }, ['./completion', '--get-yargs-completions', ''])
 
       r.logs.should.include('apple')
@@ -28,15 +25,10 @@ describe('Completion', function () {
 
     it('avoids repeating already included commands', function () {
       var r = checkUsage(function () {
-        try {
-          return yargs(['--get-yargs-completions'])
+        return yargs(['--get-yargs-completions'])
           .command('foo', 'bar')
           .command('apple', 'banana')
-          .completion()
           .argv
-        } catch (e) {
-          console.log(e.message)
-        }
       }, ['./completion', '--get-yargs-completions', 'apple'])
 
       r.logs.should.include('foo')
@@ -45,8 +37,7 @@ describe('Completion', function () {
 
     it('completes options for a command', function () {
       var r = checkUsage(function () {
-        try {
-          return yargs(['--get-yargs-completions'])
+        return yargs(['--get-yargs-completions'])
           .command('foo', 'foo command', function (subYargs) {
             subYargs.options({
               bar: {
@@ -54,14 +45,10 @@ describe('Completion', function () {
               }
             })
             .help('help')
-            .completion()
             .argv
           })
           .completion()
           .argv
-        } catch (e) {
-          console.log(e.message)
-        }
       }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
 
       r.logs.should.have.length(2)
@@ -71,15 +58,13 @@ describe('Completion', function () {
 
     it('completes options for the correct command', function () {
       var r = checkUsage(function () {
-        try {
-          return yargs(['--get-yargs-completions'])
+        return yargs(['--get-yargs-completions'])
           .command('cmd1', 'first command', function (subYargs) {
             subYargs.options({
               opt1: {
                 describe: 'first option'
               }
             })
-            .completion()
             .argv
           })
           .command('cmd2', 'second command', function (subYargs) {
@@ -88,14 +73,10 @@ describe('Completion', function () {
                 describe: 'second option'
               }
             })
-            .completion()
             .argv
           })
           .completion()
           .argv
-        } catch (e) {
-          console.log(e.message)
-        }
       }, ['./completion', '--get-yargs-completions', 'cmd2', '--o'])
 
       r.logs.should.have.length(1)
@@ -104,16 +85,12 @@ describe('Completion', function () {
 
     it('works if command has no options', function () {
       var r = checkUsage(function () {
-        try {
-          return yargs(['--get-yargs-completions'])
+        return yargs(['--get-yargs-completions'])
           .command('foo', 'foo command', function (subYargs) {
             subYargs.completion().argv
           })
           .completion()
           .argv
-        } catch (e) {
-          console.log(e.message)
-        }
       }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
 
       r.logs.should.have.length(0)

--- a/test/completion.js
+++ b/test/completion.js
@@ -43,6 +43,82 @@ describe('Completion', function () {
       r.logs.should.not.include('apple')
     })
 
+    it('completes options for a command', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('foo', 'foo command', function (subYargs) {
+            subYargs.options({
+              bar: {
+                describe: 'bar option'
+              }
+            })
+            .help('help')
+            .completion()
+            .argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
+
+      r.logs.should.have.length(2)
+      r.logs.should.include('--bar')
+      r.logs.should.include('--help')
+    })
+
+    it('completes options for the correct command', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('cmd1', 'first command', function (subYargs) {
+            subYargs.options({
+              opt1: {
+                describe: 'first option'
+              }
+            })
+            .completion()
+            .argv
+          })
+          .command('cmd2', 'second command', function (subYargs) {
+            subYargs.options({
+              opt2: {
+                describe: 'second option'
+              }
+            })
+            .completion()
+            .argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'cmd2', '--o'])
+
+      r.logs.should.have.length(1)
+      r.logs.should.include('--opt2')
+    })
+
+    it('works if command has no options', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs(['--get-yargs-completions'])
+          .command('foo', 'foo command', function (subYargs) {
+            subYargs.completion().argv
+          })
+          .completion()
+          .argv
+        } catch (e) {
+          console.log(e.message)
+        }
+      }, ['./completion', '--get-yargs-completions', 'foo', '--b'])
+
+      r.logs.should.have.length(0)
+    })
+
     it("returns arguments as completion suggestion, if next contains '-'", function () {
       var r = checkUsage(function () {
         return yargs(['--get-yargs-completions'])


### PR DESCRIPTION
I've made a couple minor tweaks to the command-specific-completion logic in #185 

we now always look for the `get-yargs-completions` option, so `yargs.completion()` only needs to be called when registering a top-level command to generate a completion script.
