### PR TITLE
Hide commands with false for description

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,8 +509,10 @@ present script similar to how `$0` works in bash or perl.
 
 Document the commands exposed by your application.
 
-use `desc` to provide a description for each command your application accepts (the
-values stored in `argv._`).
+Use `desc` to provide a description for each command your application accepts (the
+values stored in `argv._`).  Set `desc` to `false` to create a hidden command.
+Hidden commands don't show up in the help output and aren't available for
+completion.
 
 Optionally, you can provide a handler `fn` which will be executed when
 a given command is provided. The handler will be executed with an instance

--- a/index.js
+++ b/index.js
@@ -111,7 +111,9 @@ function Argv (processArgs, cwd) {
   }
 
   self.command = function (cmd, description, fn) {
-    usage.command(cmd, description)
+    if (description !== false) {
+      usage.command(cmd, description)
+    }
     if (fn) commandHandlers[cmd] = fn
     return self
   }
@@ -363,7 +365,10 @@ function Argv (processArgs, cwd) {
 
     // register the completion command.
     completionCommand = cmd || 'completion'
-    self.command(completionCommand, desc || 'generate bash completion script')
+    if (!desc && desc !== false) {
+      desc = 'generate bash completion script'
+    }
+    self.command(completionCommand, desc)
 
     // a function can be provided
     if (fn) completion.registerFunction(fn)

--- a/test/completion.js
+++ b/test/completion.js
@@ -83,6 +83,19 @@ describe('Completion', function () {
       r.logs.should.include('--opt2')
     })
 
+    it('does not complete hidden commands', function () {
+      var r = checkUsage(function () {
+        return yargs(['--get-yargs-completions'])
+          .command('cmd1', 'first command')
+          .command('cmd2', false)
+          .completion('completion', false)
+          .argv
+      }, ['./completion', '--get-yargs-completions', 'cmd'])
+
+      r.logs.should.have.length(1)
+      r.logs.should.include('cmd1')
+    })
+
     it('works if command has no options', function () {
       var r = checkUsage(function () {
         return yargs(['--get-yargs-completions'])

--- a/test/usage.js
+++ b/test/usage.js
@@ -988,6 +988,44 @@ describe('usage tests', function () {
         'Missing required arguments: y'
       ])
     })
+
+    it('should not show hidden commands', function () {
+      var r = checkUsage(function () {
+        return yargs('')
+          .command('upload', 'upload something')
+          .command('secret', false)
+          .demand('y')
+          .wrap(null)
+          .argv
+      })
+
+      r.errors.join('\n').split(/\s+/).should.deep.equal([
+        'Commands:',
+        'upload', 'upload', 'something',
+        'Options:',
+        '-y', '[required]',
+        'Missing', 'required', 'arguments:', 'y'
+      ])
+    })
+
+    it('allows completion command to be hidden', function () {
+      var r = checkUsage(function () {
+        return yargs('')
+          .command('upload', 'upload something')
+          .completion('completion', false)
+          .demand('y')
+          .wrap(null)
+          .argv
+      })
+
+      r.errors.join('\n').split(/\s+/).should.deep.equal([
+        'Commands:',
+        'upload', 'upload', 'something',
+        'Options:',
+        '-y', '[required]',
+        'Missing', 'required', 'arguments:', 'y'
+      ])
+    })
   })
 
   describe('epilogue', function () {


### PR DESCRIPTION
This makes it so calling `yargs.command('some-command', false)` will create a hidden command.  Hidden commands are not shown in the help output and are not eligible for completion.

Fixes #188.
