### PR TITLE
tweaks to how errors are reported and config loading is handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,6 +476,8 @@ function Argv (processArgs, cwd) {
       }
     })
 
+    if (parsed.error) throw parsed.error
+
     // if we're executed via bash completion, don't
     // bother with validation.
     if (!argv[completion.completionKey]) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,6 +9,8 @@ function increment (orig) {
 
 module.exports = function (args, opts) {
   if (!opts) opts = {}
+
+  var error = null
   var flags = { arrays: {}, bools: {}, strings: {}, counts: {}, normalize: {}, configs: {} }
 
   ;[].concat(opts['array']).filter(Boolean).forEach(function (key) {
@@ -232,7 +234,7 @@ module.exports = function (args, opts) {
   function eatNargs (i, key, args) {
     var toEat = checkAllAliases(key, opts.narg)
 
-    if (args.length - (i + 1) < toEat) throw Error('not enough arguments following: ' + key)
+    if (args.length - (i + 1) < toEat) error = Error('not enough arguments following: ' + key)
 
     for (var ii = i + 1; ii < (toEat + i + 1); ii++) {
       setArg(key, args[ii])
@@ -331,7 +333,7 @@ module.exports = function (args, opts) {
             }
           })
         } catch (ex) {
-          throw Error('invalid json config file: ' + configPath)
+          if (argv[configKey]) error = Error('invalid json config file: ' + configPath)
         }
       }
     })
@@ -443,6 +445,7 @@ module.exports = function (args, opts) {
   return {
     argv: argv,
     aliases: aliases,
+    error: error,
     newAliases: newAliases
   }
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -321,6 +321,22 @@ describe('parser tests', function () {
         .argv
     })
 
+    // see: https://github.com/bcoe/yargs/issues/172
+    it('should not raise an exception if config file is set as default argument value', function () {
+      var fail = false
+      yargs([])
+        .option('config', {
+          default: 'foo.json'
+        })
+        .config('config')
+        .fail(function () {
+          fail = true
+        })
+        .argv
+
+      fail.should.equal(false)
+    })
+
     it('should be displayed in the help message', function () {
       var checkUsage = require('./helpers/utils').checkOutput
       var r = checkUsage(function () {


### PR DESCRIPTION
the magic help argument is now processed before we throw errors, this solves the problem reported in #184.

We also now don't return an error, if the bad configuration file was loaded as a result of a default argument value see #172.