### PR TITLE
slight tweaks to @ggoodman's work in #203

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,7 +417,6 @@ function Argv (processArgs, cwd) {
     argv.$0 = self.$0
 
     self.parsed = parsed
-    self.commandIndex = self.commandIndex || 0
 
     // while building up the argv object, there
     // are two passes through the parser. If completion
@@ -430,14 +429,7 @@ function Argv (processArgs, cwd) {
 
     // if there's a handler associated with a
     // command defer processing to it.
-    var commandName = argv._[self.commandIndex]
-    var handler = self.getCommandHandlers()[commandName]
-
-    if (handler) {
-      self.commandIndex++
-      handler(self.reset())
-      return self.argv
-    }
+    if (handleCommand(argv)) return self.argv
 
     // generate a completion script for adding to ~/.bashrc.
     if (completionCommand && ~argv._.indexOf(completionCommand) && !argv[completion.completionKey]) {
@@ -494,6 +486,17 @@ function Argv (processArgs, cwd) {
     setPlaceholderKeys(argv)
 
     return argv
+  }
+
+  function handleCommand (argv) {
+    for (var i = 0, command, handler; (command = argv._[i]) !== undefined; i++) {
+      handler = self.getCommandHandlers()[command]
+
+      if (handler) {
+        handler(self.reset())
+        return true
+      }
+    }
   }
 
   function setPlaceholderKeys (argv) {

--- a/index.js
+++ b/index.js
@@ -432,11 +432,11 @@ function Argv (processArgs, cwd) {
     // command defer processing to it.
     var commandName = argv._[self.commandIndex]
     var handler = self.getCommandHandlers()[commandName]
-    
+
     if (handler) {
-        self.commandIndex++;
-        handler(self.reset())
-        return self.argv;
+      self.commandIndex++
+      handler(self.reset())
+      return self.argv
     }
 
     // generate a completion script for adding to ~/.bashrc.

--- a/index.js
+++ b/index.js
@@ -417,6 +417,7 @@ function Argv (processArgs, cwd) {
     argv.$0 = self.$0
 
     self.parsed = parsed
+    self.commandIndex = self.commandIndex || 0
 
     // while building up the argv object, there
     // are two passes through the parser. If completion
@@ -429,12 +430,13 @@ function Argv (processArgs, cwd) {
 
     // if there's a handler associated with a
     // command defer processing to it.
-    var handlerKeys = Object.keys(self.getCommandHandlers())
-    for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
-      if (~argv._.indexOf(command)) {
-        self.getCommandHandlers()[command](self.reset())
-        return self.argv
-      }
+    var commandName = argv._[self.commandIndex]
+    var handler = self.getCommandHandlers()[commandName]
+    
+    if (handler) {
+        self.commandIndex++;
+        handler(self.reset())
+        return self.argv;
     }
 
     // generate a completion script for adding to ~/.bashrc.

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -223,6 +223,53 @@ describe('yargs dsl tests', function () {
       ])
     })
 
+    it('runs command handler if node-bin is included in path', function () {
+      var r = checkOutput(function () {
+        yargs(['/Users/benjamincoe/.nvm/versions/io.js/v2.0.2/bin/iojs', 'blerg', '-h'])
+          .command('blerg', 'handle blerg things', function (yargs) {
+            yargs.command('snuh', 'snuh command')
+              .help('h')
+              .wrap(null)
+              .argv
+          })
+          .help('h')
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  snuh  snuh command',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('checks commands based on their order in argv._', function () {
+      var r = checkOutput(function () {
+        yargs(['blerg', 'noop', '-h'])
+          .command('noop', 'do nothing', function () {})
+          .command('blerg', 'handle blerg things', function (yargs) {
+            yargs.command('snuh', 'snuh command')
+              .help('h')
+              .wrap(null)
+              .argv
+          })
+          .help('h')
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  snuh  snuh command',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
     it('executes top-level help if no handled command is provided', function () {
       var r = checkOutput(function () {
         yargs(['snuh', '-h'])


### PR DESCRIPTION
I've made a couple slight tweaks to the pull request in #203 (also see #202).

First off, thanks for reporting and tackling this @ggoodman, this makes commands significantly more powerful. I've made a couple small changes:

* I added some unit-tests, including one I found for the edge-case where the node-bin is in `_.argv`.
* I modified your approach slightly:
  * the core of the problem was that commands were getting checked in the order they were defined.
  * the solution was to instead iterate over `argv._` in order.

Could you give this branch a try and let me know if it does the trick for you.