### PR TITLE
Choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,40 @@ var argv = require('yargs')
 ;
 ````
 
+.choices(key, choices)
+----------------------
+
+Limit valid values for `key` to a predefined set of `choices`, given as an array
+or as an individual value.
+
+```js
+var argv = require('yargs')
+  .alias('i', 'ingredient')
+  .describe('i', 'choose your sandwich ingredients')
+  .choices('i', ['peanut-butter', 'jelly', 'banana', 'pickles'])
+  .help('help')
+  .argv
+```
+
+If this method is called multiple times, all enumerated values will be merged
+together. Choices are generally strings or numbers, and value matching is
+case-sensitive.
+
+Optionally `.choices()` can take an object that maps multiple keys to their
+choices.
+
+Choices can also be specified as `choices` in the object given to `option()`.
+
+```js
+var argv = require('yargs')
+  .option('size', {
+    alias: 's',
+    describe: 'choose a size',
+    choices: ['xs', 's', 'm', 'l', 'xl']
+  })
+  .argv
+```
+
 .usage(message, [opts])
 ---------------------
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function Argv (processArgs, cwd) {
       alias: {},
       default: {},
       defaultDescription: {},
+      choices: {},
       requiresArg: [],
       count: [],
       normalize: [],
@@ -90,6 +91,17 @@ function Argv (processArgs, cwd) {
       })
     } else {
       options.narg[key] = n
+    }
+    return self
+  }
+
+  self.choices = function (key, values) {
+    if (typeof key === 'object') {
+      Object.keys(key).forEach(function (k) {
+        self.choices(k, key[k])
+      })
+    } else {
+      options.choices[key] = (options.choices[key] || []).concat(values)
     }
     return self
   }
@@ -262,6 +274,8 @@ function Argv (processArgs, cwd) {
         self.default(key, opt.default)
       } if ('nargs' in opt) {
         self.nargs(key, opt.nargs)
+      } if ('choices' in opt) {
+        self.choices(key, opt.choices)
       } if (opt.boolean || opt.type === 'boolean') {
         self.boolean(key)
         if (opt.alias) self.boolean(opt.alias)
@@ -486,6 +500,7 @@ function Argv (processArgs, cwd) {
       validation.requiredArguments(argv)
       if (strict) validation.unknownArguments(argv, aliases)
       validation.customChecks(argv, aliases)
+      validation.limitedChoices(argv)
       validation.implications(argv)
     }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -167,6 +167,8 @@ module.exports = function (yargs) {
         var extra = [
             type,
             demanded[key] ? '[required]' : null,
+            options.choices && options.choices[key] ? '[choices: ' +
+              self.stringifiedValues(options.choices[key]) + ']' : null,
             defaultString(options.default[key], options.defaultDescription[key])
           ].filter(Boolean).join(' ')
 
@@ -267,6 +269,21 @@ module.exports = function (yargs) {
     }
     var description = fn.name ? decamelize(fn.name, '-') : 'generated-value'
     return ['(', description, ')'].join('')
+  }
+
+  self.stringifiedValues = function (values, separator) {
+    var string = ''
+    var sep = separator || ', '
+    var array = [].concat(values)
+
+    if (!values || !array.length) return string
+
+    array.forEach(function (value) {
+      if (string.length) string += sep
+      string += JSON.stringify(value)
+    })
+
+    return string
   }
 
   // format the default-value-string displayed in

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -109,6 +109,39 @@ module.exports = function (yargs, usage) {
     }
   }
 
+  // validate arguments limited to enumerated choices
+  self.limitedChoices = function (argv) {
+    var options = yargs.getOptions()
+    var invalid = {}
+
+    if (!Object.keys(options.choices).length) return
+
+    Object.keys(argv).forEach(function (key) {
+      if (key !== '$0' && key !== '_' &&
+        options.choices.hasOwnProperty(key)) {
+        [].concat(argv[key]).forEach(function (value) {
+          // TODO case-insensitive configurability
+          if (options.choices[key].indexOf(value) === -1) {
+            invalid[key] = (invalid[key] || []).concat(value)
+          }
+        })
+      }
+    })
+
+    var invalidKeys = Object.keys(invalid)
+
+    if (!invalidKeys.length) return
+
+    var msg = 'Invalid values:'
+    invalidKeys.forEach(function (key) {
+      msg += ('\n  Argument: ' + key + ', Given: ' +
+        usage.stringifiedValues(invalid[key]) + ', Choices: ' +
+        usage.stringifiedValues(options.choices[key])
+      )
+    })
+    usage.fail(msg)
+  }
+
   // custom checks, added using the `check` option on yargs.
   var checks = []
   self.check = function (f) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1261,4 +1261,53 @@ describe('usage tests', function () {
       })
     })
   })
+
+  describe('choices', function () {
+    it('should output choices when defined for non-hidden options', function () {
+      var r = checkUsage(function () {
+        return yargs(['--help'])
+          .option('answer', {
+            describe: 'does this look good?',
+            choices: ['yes', 'no', 'maybe']
+          })
+          .option('confidence', {
+            describe: 'percentage of confidence',
+            choices: [0, 25, 50, 75, 100]
+          })
+          .help('help')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --answer      does this look good?  [choices: "yes", "no", "maybe"]',
+        '  --confidence  percentage of confidence  [choices: 0, 25, 50, 75, 100]',
+        '  --help        Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('should not output choices when defined for hidden options', function () {
+      var r = checkUsage(function () {
+        return yargs(['--help'])
+          .option('answer', {
+            type: 'string',
+            choices: ['yes', 'no', 'maybe']
+          })
+          .option('confidence', {
+            choices: [0, 25, 50, 75, 100]
+          })
+          .help('help')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
+  })
 })

--- a/test/validation.js
+++ b/test/validation.js
@@ -86,7 +86,10 @@ describe('validation tests', function () {
       yargs(['--state', 'denial'])
         .choices('state', ['happy', 'sad', 'hungry'])
         .fail(function (msg) {
-          msg.should.match(/Invalid values/)
+          msg.split('\n').should.deep.equal([
+            'Invalid values:',
+            '  Argument: state, Given: "denial", Choices: "happy", "sad", "hungry"'
+          ])
           return done()
         })
         .argv
@@ -96,17 +99,23 @@ describe('validation tests', function () {
       yargs(['--characters', 'susie', '--characters', 'linus'])
         .choices('characters', ['calvin', 'hobbes', 'susie', 'moe'])
         .fail(function (msg) {
-          msg.should.match(/Invalid values/)
+          msg.split('\n').should.deep.equal([
+            'Invalid values:',
+            '  Argument: characters, Given: "linus", Choices: "calvin", "hobbes", "susie", "moe"'
+          ])
           return done()
         })
         .argv
     })
 
-    it('fails with multiple invalid values', function (done) {
+    it('fails with multiple invalid values for same argument', function (done) {
       yargs(['--category', 'comedy', '--category', 'drama'])
         .choices('category', ['animal', 'vegetable', 'mineral'])
         .fail(function (msg) {
-          msg.should.match(/Invalid values/)
+          msg.split('\n').should.deep.equal([
+            'Invalid values:',
+            '  Argument: category, Given: "comedy", "drama", Choices: "animal", "vegetable", "mineral"'
+          ])
           return done()
         })
         .argv
@@ -116,7 +125,25 @@ describe('validation tests', function () {
       yargs(['--env', 'DEV'])
         .choices('env', ['dev', 'prd'])
         .fail(function (msg) {
-          msg.should.match(/Invalid values/)
+          msg.split('\n').should.deep.equal([
+            'Invalid values:',
+            '  Argument: env, Given: "DEV", Choices: "dev", "prd"'
+          ])
+          return done()
+        })
+        .argv
+    })
+
+    it('fails with multiple invalid arguments', function (done) {
+      yargs(['--system', 'osx', '--arch', '64'])
+        .choices('system', ['linux', 'mac', 'windows'])
+        .choices('arch', ['x86', 'x64', 'arm'])
+        .fail(function (msg) {
+          msg.split('\n').should.deep.equal([
+            'Invalid values:',
+            '  Argument: system, Given: "osx", Choices: "linux", "mac", "windows"',
+            '  Argument: arch, Given: 64, Choices: "x86", "x64", "arm"'
+          ])
           return done()
         })
         .argv

--- a/test/validation.js
+++ b/test/validation.js
@@ -80,4 +80,46 @@ describe('validation tests', function () {
         .argv
     })
   })
+
+  describe('choices', function () {
+    it('fails with one invalid value', function (done) {
+      yargs(['--state', 'denial'])
+        .choices('state', ['happy', 'sad', 'hungry'])
+        .fail(function (msg) {
+          msg.should.match(/Invalid values/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails with one valid and one invalid value', function (done) {
+      yargs(['--characters', 'susie', '--characters', 'linus'])
+        .choices('characters', ['calvin', 'hobbes', 'susie', 'moe'])
+        .fail(function (msg) {
+          msg.should.match(/Invalid values/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails with multiple invalid values', function (done) {
+      yargs(['--category', 'comedy', '--category', 'drama'])
+        .choices('category', ['animal', 'vegetable', 'mineral'])
+        .fail(function (msg) {
+          msg.should.match(/Invalid values/)
+          return done()
+        })
+        .argv
+    })
+
+    it('fails with case-insensitive value', function (done) {
+      yargs(['--env', 'DEV'])
+        .choices('env', ['dev', 'prd'])
+        .fail(function (msg) {
+          msg.should.match(/Invalid values/)
+          return done()
+        })
+        .argv
+    })
+  })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -98,6 +98,16 @@ describe('yargs dsl tests', function () {
     argv.c.should.eql('99')
   })
 
+  it('should allow a valid choice', function () {
+    var argv = yargs(['--looks=good'])
+      .option('looks', {
+        choices: ['good', 'bad']
+      })
+      .argv
+
+    argv.looks.should.eql('good')
+  })
+
   describe('showHelpOnFail', function () {
     it('should display custom failure message, if string is provided as first argument', function () {
       var r = checkOutput(function () {
@@ -252,6 +262,49 @@ describe('yargs dsl tests', function () {
   describe('terminalWidth', function () {
     it('returns the maximum width of the terminal', function () {
       yargs.terminalWidth().should.be.gt(0)
+    })
+  })
+
+  describe('choices', function () {
+    it('accepts an object', function () {
+      var optChoices = yargs([])
+        .choices({
+          color: ['red', 'green', 'blue'],
+          stars: [1, 2, 3, 4, 5]
+        })
+        .choices({
+          size: ['xl', 'l', 'm', 's', 'xs']
+        })
+        .getOptions().choices
+
+      optChoices.should.deep.equal({
+        color: ['red', 'green', 'blue'],
+        stars: [1, 2, 3, 4, 5],
+        size: ['xl', 'l', 'm', 's', 'xs']
+      })
+    })
+
+    it('accepts a string and array', function () {
+      var optChoices = yargs([])
+        .choices('meat', ['beef', 'chicken', 'pork', 'bison'])
+        .choices('temp', ['rare', 'med-rare', 'med', 'med-well', 'well'])
+        .getOptions().choices
+
+      optChoices.should.deep.equal({
+        meat: ['beef', 'chicken', 'pork', 'bison'],
+        temp: ['rare', 'med-rare', 'med', 'med-well', 'well']
+      })
+    })
+
+    it('accepts a string and single value', function () {
+      var optChoices = yargs([])
+        .choices('gender', 'male')
+        .choices('gender', 'female')
+        .getOptions().choices
+
+      optChoices.should.deep.equal({
+        gender: ['male', 'female']
+      })
     })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -160,6 +160,7 @@ describe('yargs dsl tests', function () {
         .string('foo')
         .alias('foo', 'bar')
         .string('foo')
+        .choices('foo', ['bar', 'baz'])
         .implies('foo', 'snuh')
         .strict()
         .exitProcess(false)  // defaults to true.
@@ -174,6 +175,7 @@ describe('yargs dsl tests', function () {
         key: {},
         narg: {},
         defaultDescription: {},
+        choices: {},
         requiresArg: [],
         count: [],
         normalize: [],


### PR DESCRIPTION
:white_check_mark: Fixes #101.

### Overview

Adds `choices` to the yargs API, as a method and `option()` property. Allows an argument to require a value from a predefined/enumerated set, which seems to be a common requirement and useful feature for CLIs. Previously, developers had to implement a custom `check` to enforce this. Now, it can be part of the awesomeness that yargs provides out-of-the-box.

Here's some basic usage:

```js
// choices.js
var argv = require('yargs')
  .option('size', {
    alias: 's',
    describe: 'choose a size',
    choices: ['xs', 's', 'm', 'l', 'xl']
  })
  .help('help')
  .argv

console.dir(argv)
```

```sh
$ node choices.js --help
Options:
  --size, -s  choose a size                 [choices: "xs", "s", "m", "l", "xl"]
  --help      Show help                                                [boolean]

$ node choices.js -s nope
Options:
  --size, -s  choose a size                 [choices: "xs", "s", "m", "l", "xl"]
  --help      Show help                                                [boolean]

Invalid values:
  Argument: size, Given: "nope", Choices: "xs", "s", "m", "l", "xl"

$ node choices.js -s l
{ _: [], help: false, s: 'l', size: 'l', '$0': 'choices.js' }
```

### Notes

Currently requires case-sensitive matching. Would be nice to allow `choices` to be somehow configurable to allow case-insensitive matching.

Individual string-valued choices are output with double-quotes (via `JSON.stringify(value)`) for consistency with current `default` value display.

I wasn't sure exactly where to add `choices` to the README (methods don't seem to be in any particular order), but this can be addressed later with README refactoring (#92).

Also wasn't quite sure how to organize the additional unit tests, so I made `choices` categories under existing files.

Otherwise, I did my best to follow yargs API and coding conventions, attempting to be as lenient as possible with allowed method arguments.

According to my test runs, code coverage changes from this on *master*:

```
  224 passing (4s)

----------------|----------|----------|----------|----------|----------------|
File            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------|----------|----------|----------|----------|----------------|
 __root__/      |      100 |    93.29 |      100 |      100 |                |
  index.js      |      100 |    93.29 |      100 |      100 |                |
 lib/           |     98.6 |    94.54 |      100 |      100 |                |
  completion.js |      100 |      100 |      100 |      100 |                |
  parser.js     |     99.6 |    97.83 |      100 |      100 |                |
  usage.js      |    96.05 |    86.87 |      100 |      100 |                |
  validation.js |      100 |    95.65 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
All files       |    99.09 |    94.15 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
```

To this on my *choices* branch:

```
  234 passing (5s)

----------------|----------|----------|----------|----------|----------------|
File            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------|----------|----------|----------|----------|----------------|
 __root__/      |      100 |    94.12 |      100 |      100 |                |
  index.js      |      100 |    94.12 |      100 |      100 |                |
 lib/           |    98.49 |    94.63 |      100 |      100 |                |
  completion.js |      100 |      100 |      100 |      100 |                |
  parser.js     |     99.6 |    97.83 |      100 |      100 |                |
  usage.js      |    95.74 |    87.39 |      100 |      100 |                |
  validation.js |      100 |    96.34 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
All files       |    99.02 |    94.47 |      100 |      100 |                |
----------------|----------|----------|----------|----------|----------------|
```

Hopefully that's acceptable. :sunglasses: