### PR TITLE
Add missing locale strings to y18n lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function Argv (processArgs, cwd) {
   }
 
   self.config = function (key, msg) {
-    self.describe(key, msg || y18n.__('Path to JSON config file'))
+    self.describe(key, msg || usage.deferY18nLookup('Path to JSON config file'))
     options.config.push.apply(options.config, [].concat(key))
     return self
   }
@@ -336,7 +336,7 @@ function Argv (processArgs, cwd) {
     versionOpt = opt || 'version'
     usage.version(ver)
     self.boolean(versionOpt)
-    self.describe(versionOpt, msg || y18n.__('Show version number'))
+    self.describe(versionOpt, msg || usage.deferY18nLookup('Show version number'))
     return self
   }
 
@@ -344,7 +344,7 @@ function Argv (processArgs, cwd) {
   self.addHelpOpt = function (opt, msg) {
     helpOpt = opt
     self.boolean(opt)
-    self.describe(helpOpt, msg || y18n.__('Show help'))
+    self.describe(helpOpt, msg || usage.deferY18nLookup('Show help'))
     return self
   }
 

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ function Argv (processArgs, cwd) {
   self.addHelpOpt = function (opt, msg) {
     helpOpt = opt
     self.boolean(opt)
-    self.describe(helpOpt, msg || usage.deferY18nLookup('Show help'))
+    self.describe(opt, msg || usage.deferY18nLookup('Show help'))
     return self
   }
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function Argv (processArgs, cwd) {
   }
 
   self.config = function (key, msg) {
-    self.describe(key, msg || 'Path to JSON config file')
+    self.describe(key, msg || y18n.__('Path to JSON config file'))
     options.config.push.apply(options.config, [].concat(key))
     return self
   }
@@ -336,7 +336,7 @@ function Argv (processArgs, cwd) {
     versionOpt = opt || 'version'
     usage.version(ver)
     self.boolean(versionOpt)
-    self.describe(versionOpt, msg || 'Show version number')
+    self.describe(versionOpt, msg || y18n.__('Show version number'))
     return self
   }
 
@@ -344,7 +344,7 @@ function Argv (processArgs, cwd) {
   self.addHelpOpt = function (opt, msg) {
     helpOpt = opt
     self.boolean(opt)
-    self.describe(opt, msg || 'Show help')
+    self.describe(helpOpt, msg || y18n.__('Show help'))
     return self
   }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -91,6 +91,11 @@ module.exports = function (yargs, y18n) {
     wrap = cols
   }
 
+  var deferY18nLookupPrefix = '__yargsString__:'
+  self.deferY18nLookup = function (str) {
+    return deferY18nLookupPrefix + str
+  }
+
   self.help = function () {
     normalizeAliases()
 
@@ -158,6 +163,8 @@ module.exports = function (yargs, y18n) {
         var kswitch = switches[key]
         var desc = descriptions[key] || ''
         var type = null
+
+        if (~desc.lastIndexOf(deferY18nLookupPrefix)) desc = __(desc.substring(deferY18nLookupPrefix.length))
 
         if (~options.boolean.indexOf(key)) type = '[' + __('boolean') + ']'
         if (~options.count.indexOf(key)) type = '[' + __('count') + ']'

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,5 +29,8 @@
   "Argument check failed: %s": "Argument check failed: %s",
   "Implications failed:": "Implications failed:",
   "not enough arguments following: %s": "not enough arguments following: %s",
-  "invalid json config file: %s": "invalid json config file: %s"
+  "invalid json config file: %s": "invalid json config file: %s",
+  "Path to JSON config file": "Path to JSON config file",
+  "Show help": "Show help",
+  "Show version number": "Show version number"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -30,7 +30,7 @@
   "Implications failed:": "Implicaciones fracasadas:",
   "not enough arguments following: %s": "no hay suficientes argumentos después de: %s",
   "invalid json config file: %s": "archivo de configuración json inválido: %s",
-  "Path to JSON config file": "Ruta al archivo de configuración JSON: %s",
+  "Path to JSON config file": "Ruta al archivo de configuración JSON",
   "Show help": "Muestra ayuda",
   "Show version number": "Muestra número de versión"
 }

--- a/locales/pirate.json
+++ b/locales/pirate.json
@@ -6,5 +6,7 @@
   "Missing required argument: %s": {
     "one": "Ye be havin' to set the followin' argument land lubber: %s",
     "other": "Ye be havin' to set the followin' arguments land lubber: %s"
-  }
+  },
+  "Show help": "Parlay this here code of conduct",
+  "Show version number": "'Tis the version ye be askin' fer"
 }

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -336,6 +336,18 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Parlay this here code of conduct/)
     })
 
+    it('uses locale string for help option default desc on .help().locale()', function () {
+      var r = checkOutput(function () {
+        yargs(['-h'])
+          .help('h')
+          .locale('pirate')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs.join(' ').should.match(/Parlay this here code of conduct/)
+    })
+
     describe('updateLocale', function () {
       it('allows you to override the default locale strings', function () {
         var r = checkOutput(function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -324,6 +324,18 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Choose yer command:/)
     })
 
+    it('uses locale string for help option default desc on .locale().help()', function () {
+      var r = checkOutput(function () {
+        yargs(['-h'])
+          .locale('pirate')
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs.join(' ').should.match(/Parlay this here code of conduct/)
+    })
+
     describe('updateLocale', function () {
       it('allows you to override the default locale strings', function () {
         var r = checkOutput(function () {


### PR DESCRIPTION
:heavy_plus_sign: Further testing revealed the following strings used in `index.js` were missing from y18n lookup:

```json
"Path to JSON config file": "Path to JSON config file",
"Show help": "Show help",
"Show version number": "Show version number"
```

This PR fixes that.

Note that [the first commit](https://github.com/bcoe/yargs/commit/3a523eb086c4c877f2e837b3ee9f02523e6fe0fa) takes the naive approach, which results in using the `en` version for `'Show help'` in this scenario:

```js
var argv = require('yargs').help('h').locale('pirate').argv
```

[The second commit](https://github.com/bcoe/yargs/commit/01e91c7f9ad51d67f235540567ed8362d97760c6) addresses this by deferring the y18n lookup until the whole usage content is generated, instead of doing it when the option is defined.

Also note that this PR **does not** attempt to address the problem of updating locale strings *before* the desired locale is set (if it even *is* a problem):

```js
var argv = require('yargs')
  .help('h')
  .updateStrings({
    'Show help': 'Use this here help desc instead' // applies to default locale en
  })
  .locale('pirate') // changes locale and thus discards previously updated strings
  .argv
```

See related discussion in PR #220.