### PR TITLE
Add missing locale strings to FR locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ Choose yer command:
 
 Options for me hearties!
   --option, -o  'tis a mighty fine option               [requi-yar-ed]
-  --help        Show help                                    [boolean]
+  --help        Parlay this here code of conduct             [boolean]
 
 Ex. marks the spot:
   test.js run foo  shiver me timbers, here's an example for ye
@@ -687,8 +687,8 @@ Ye be havin' to set the followin' argument land lubber: option
 Locales currently supported:
 
 * **en:** American English.
-* **fr:** French.
 * **es:** Spanish.
+* **fr:** French.
 * **pirate:** American Pirate.
 
 To submit a new translation for yargs:
@@ -933,6 +933,9 @@ My Commands -->
 Options:
   --help  Show help  [boolean]
 ```
+
+If you explicitly specify a `locale()`, you should do so *before* calling
+`updateStrings()`.
 
 .usage(message, [opts])
 ---------------------

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -235,7 +235,7 @@ module.exports = function (args, opts, y18n) {
   function eatNargs (i, key, args) {
     var toEat = checkAllAliases(key, opts.narg)
 
-    if (args.length - (i + 1) < toEat) error = Error(__('not enough arguments following: %s', key))
+    if (args.length - (i + 1) < toEat) error = Error(__('Not enough arguments following: %s', key))
 
     for (var ii = i + 1; ii < (toEat + i + 1); ii++) {
       setArg(key, args[ii])
@@ -334,7 +334,7 @@ module.exports = function (args, opts, y18n) {
             }
           })
         } catch (ex) {
-          if (argv[configKey]) error = Error(__('invalid json config file: %s', configPath))
+          if (argv[configKey]) error = Error(__('Invalid JSON config file: %s', configPath))
         }
       }
     })

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,8 +28,8 @@
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Given: %s, Choices: %s",
   "Argument check failed: %s": "Argument check failed: %s",
   "Implications failed:": "Implications failed:",
-  "not enough arguments following: %s": "not enough arguments following: %s",
-  "invalid json config file: %s": "invalid json config file: %s",
+  "Not enough arguments following: %s": "Not enough arguments following: %s",
+  "Invalid JSON config file: %s": "Invalid JSON config file: %s",
   "Path to JSON config file": "Path to JSON config file",
   "Show help": "Show help",
   "Show version number": "Show version number"

--- a/locales/es.json
+++ b/locales/es.json
@@ -28,8 +28,8 @@
   "Argument: %s, Given: %s, Choices: %s": "Argumento: %s, Recibido: %s, Selección: %s",
   "Argument check failed: %s": "Verificación de argumento ha fracasado: %s",
   "Implications failed:": "Implicaciones fracasadas:",
-  "not enough arguments following: %s": "no hay suficientes argumentos después de: %s",
-  "invalid json config file: %s": "archivo de configuración json inválido: %s",
+  "Not enough arguments following: %s": "No hay suficientes argumentos después de: %s",
+  "Invalid JSON config file: %s": "Archivo de configuración JSON inválido: %s",
   "Path to JSON config file": "Ruta al archivo de configuración JSON",
   "Show help": "Muestra ayuda",
   "Show version number": "Muestra número de versión"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -29,5 +29,8 @@
   "Argument check failed: %s": "Echec de la vérification de l'argument: %s",
   "Implications failed:": "Implications échouées:",
   "not enough arguments following: %s": "pas assez d'arguments suivant: %s",
-  "invalid json config file: %s": "fichier de configuration json invalide: %s"
+  "invalid json config file: %s": "fichier de configuration json invalide: %s",
+  "Path to JSON config file": "Chemin du fichier de configuration JSON",
+  "Show help": "Affiche de l'aide",
+  "Show version number": "Affiche le numéro de version"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -28,8 +28,8 @@
   "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Donné: %s, Choix: %s",
   "Argument check failed: %s": "Echec de la vérification de l'argument: %s",
   "Implications failed:": "Implications échouées:",
-  "not enough arguments following: %s": "pas assez d'arguments suivant: %s",
-  "invalid json config file: %s": "fichier de configuration json invalide: %s",
+  "Not enough arguments following: %s": "Pas assez d'arguments suivant: %s",
+  "Invalid JSON config file: %s": "Fichier de configuration JSON invalide: %s",
   "Path to JSON config file": "Chemin du fichier de configuration JSON",
   "Show help": "Affiche de l'aide",
   "Show version number": "Affiche le numéro de version"

--- a/test/parser.js
+++ b/test/parser.js
@@ -315,7 +315,7 @@ describe('parser tests', function () {
         .alias('z', 'zoom')
         .config('settings')
         .fail(function (msg) {
-          msg.should.eql('invalid json config file: fake.json')
+          msg.should.eql('Invalid JSON config file: fake.json')
           return done()
         })
         .argv
@@ -1021,7 +1021,7 @@ describe('parser tests', function () {
       expect(function () {
         yargs().nargs('foo', 2)
           .parse([ '--foo', 'apple'])
-      }).to.throw('not enough arguments following: foo')
+      }).to.throw('Not enough arguments following: foo')
     })
 
     it('nargs is applied to aliases', function () {


### PR DESCRIPTION
:fr: Some strings were found to be previously missing from y18n lookup; this adds them to `fr.json` with an attempted French translation:

```json
"Path to JSON config file": "Chemin du fichier de configuration JSON",
"Show help": "Affiche de l'aide",
"Show version number": "Affiche le numéro de version"
```

See related discussion in PRs #220 and #221.

@LoicMahieu If you have time, I would greatly appreciate a quick review of these French translations. Thanks!