### PR TITLE
a couple slight tweaks to @sgentle's configuration fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,8 @@ function Argv (processArgs, cwd) {
 
       if (demand) {
         self.demand(key, demand)
+      } if ('config' in opt) {
+        self.config(key)
       } if ('default' in opt) {
         self.default(key, opt.default)
       } if ('nargs' in opt) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -328,7 +328,7 @@ module.exports = function (args, opts, y18n) {
           Object.keys(config).forEach(function (key) {
             // setting arguments via CLI takes precedence over
             // values within the config file.
-            if (argv[key] === undefined) {
+            if (argv[key] === undefined || (flags.bools[key] && !argv[key])) {
               delete argv[key]
               setArg(key, config[key])
             }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -58,7 +58,7 @@ module.exports = function (args, opts, y18n) {
 
   Object.keys(flags.bools).forEach(function (key) {
     setArg(key, !(key in defaults) ? false : defaults[key])
-    flags.defaulted[key] = true
+    setDefaulted(key)
   })
 
   var notFlags = []
@@ -259,7 +259,7 @@ module.exports = function (args, opts, y18n) {
   }
 
   function setArg (key, val) {
-    delete flags.defaulted[key]
+    unsetDefaulted(key)
 
     // handle parsing boolean arguments --foo=true --bar false.
     if (checkAllAliases(key, flags.bools) || checkAllAliases(key, flags.counts)) {
@@ -416,6 +416,18 @@ module.exports = function (args, opts, y18n) {
     })
 
     return isSet
+  }
+
+  function setDefaulted (key) {
+    [].concat(aliases[key] || [], key).forEach(function (k) {
+      flags.defaulted[k] = true
+    })
+  }
+
+  function unsetDefaulted (key) {
+    [].concat(aliases[key] || [], key).forEach(function (k) {
+      delete flags.defaulted[k]
+    })
   }
 
   // return a default value, given the type of a flag.,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,7 +12,7 @@ module.exports = function (args, opts, y18n) {
 
   var __ = y18n.__
   var error = null
-  var flags = { arrays: {}, bools: {}, strings: {}, counts: {}, normalize: {}, configs: {} }
+  var flags = { arrays: {}, bools: {}, strings: {}, counts: {}, normalize: {}, configs: {}, defaulted: {} }
 
   ;[].concat(opts['array']).filter(Boolean).forEach(function (key) {
     flags.arrays[key] = true
@@ -58,6 +58,7 @@ module.exports = function (args, opts, y18n) {
 
   Object.keys(flags.bools).forEach(function (key) {
     setArg(key, !(key in defaults) ? false : defaults[key])
+    flags.defaulted[key] = true
   })
 
   var notFlags = []
@@ -258,6 +259,8 @@ module.exports = function (args, opts, y18n) {
   }
 
   function setArg (key, val) {
+    delete flags.defaulted[key]
+
     // handle parsing boolean arguments --foo=true --bar false.
     if (checkAllAliases(key, flags.bools) || checkAllAliases(key, flags.counts)) {
       if (typeof val === 'string') val = val === 'true'
@@ -328,7 +331,7 @@ module.exports = function (args, opts, y18n) {
           Object.keys(config).forEach(function (key) {
             // setting arguments via CLI takes precedence over
             // values within the config file.
-            if (argv[key] === undefined || (flags.bools[key] && !argv[key])) {
+            if (argv[key] === undefined || (flags.defaulted[key])) {
               delete argv[key]
               setArg(key, config[key])
             }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
     "nyc": "^3.1.0",
-    "standard": "^4.4.0"
+    "standard": "^5.0.2"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks",

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -2,5 +2,6 @@
     "herp": "derp",
     "z": 55,
     "foo": "baz",
-    "version": "1.0.2"
+    "version": "1.0.2",
+    "truthy": true
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -310,9 +310,22 @@ describe('parser tests', function () {
 
     it('should load options and values from a file when config is used', function () {
       var argv = yargs([ '--settings', jsonPath, '--foo', 'bar' ])
-      .alias('z', 'zoom')
-      .config('settings')
-      .argv
+        .alias('z', 'zoom')
+        .config('settings')
+        .argv
+
+      argv.should.have.property('herp', 'derp')
+      argv.should.have.property('zoom', 55)
+      argv.should.have.property('foo').and.deep.equal('bar')
+    })
+
+    it("should allow config to be set as flag in 'option'", function () {
+      var argv = yargs([ '--settings', jsonPath, '--foo', 'bar' ])
+        .alias('z', 'zoom')
+        .option('settings', {
+          config: true
+        })
+        .argv
 
       argv.should.have.property('herp', 'derp')
       argv.should.have.property('zoom', 55)

--- a/test/parser.js
+++ b/test/parser.js
@@ -275,6 +275,16 @@ describe('parser tests', function () {
       argv.should.have.property('foo').and.deep.equal('baz')
     })
 
+    it('should use value from config file, if argv key is a boolean', function () {
+      var argv = yargs([])
+      .config('settings')
+      .default('settings', jsonPath)
+      .boolean('truthy')
+      .argv
+
+      argv.should.have.property('truthy', true)
+    })
+
     it('should use cli value, if cli value is set and both cli and default value match', function () {
       var argv = yargs(['--foo', 'banana'])
       .alias('z', 'zoom')

--- a/test/parser.js
+++ b/test/parser.js
@@ -285,6 +285,16 @@ describe('parser tests', function () {
       argv.should.have.property('truthy', true)
     })
 
+    it('should use value from cli, if cli overrides boolean argv key', function () {
+      var argv = yargs(['--no-truthy'])
+      .config('settings')
+      .default('settings', jsonPath)
+      .boolean('truthy')
+      .argv
+
+      argv.should.have.property('truthy', false)
+    })
+
     it('should use cli value, if cli value is set and both cli and default value match', function () {
       var argv = yargs(['--foo', 'banana'])
       .alias('z', 'zoom')

--- a/test/parser.js
+++ b/test/parser.js
@@ -106,7 +106,7 @@ describe('parser tests', function () {
   })
 
   it('should group values into an array if the same option is specified multiple times', function () {
-    var parse = yargs.parse(['-v', 'a', '-v', 'b', '-v', 'c' ])
+    var parse = yargs.parse(['-v', 'a', '-v', 'b', '-v', 'c'])
     parse.should.have.property('v').and.deep.equal(['a', 'b', 'c'])
     parse.should.have.property('_').with.length(0)
   })
@@ -1053,7 +1053,7 @@ describe('parser tests', function () {
     it('should raise an exception if there are not enough arguments following key', function () {
       expect(function () {
         yargs().nargs('foo', 2)
-          .parse([ '--foo', 'apple'])
+          .parse(['--foo', 'apple'])
       }).to.throw('not enough arguments following: foo')
     })
 
@@ -1086,7 +1086,7 @@ describe('parser tests', function () {
         .option('bar', {
           nargs: 2
         })
-        .parse([ '-f=apple', 'bar', 'blerg', '--bar=monkey', 'washing', 'cat'])
+        .parse(['-f=apple', 'bar', 'blerg', '--bar=monkey', 'washing', 'cat'])
 
       result.f[0].should.equal('apple')
       result.f[1].should.equal('bar')


### PR DESCRIPTION
@sgentle made a couple slight tweaks to #223 to make it even more awesome:

* defaulted now takes into account aliases, this way you can have the `help` key set in your config file, and if you have `.alias('h', 'help')` yargs will set both the `h` and `help` key based on your JSON config.
* I made it so that you can specify `config` in the options block, because why not?

```js
yargs.option('config', {
  config: true
})
```

reviewers: @sgentle, @nexdrew.