### PR TITLE
detect a user's locale using os-locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,8 @@ Optionally `.implies()` can accept an object specifying multiple implications.
 .locale(locale)
 ---------------
 
-Set a locale other than the default `en` locale:
+Set a locale other than the operating system's default locale, you can modify this
+value by exporting `LC_ALL`.
 
 ```js
 var argv = require('yargs')
@@ -670,6 +671,11 @@ var argv = require('yargs')
   .locale('pirate')
   .argv
 ```
+
+.locale()
+---------
+
+Return the locale that yargs has detected.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -650,11 +650,24 @@ Given the key `x` is set, it is required that the key `y` is set.
 
 Optionally `.implies()` can accept an object specifying multiple implications.
 
+.locale()
+---------
+
+Return the locale that yargs is currently using.
+
+By default, yargs will auto-detect the operating system's locale
+(via [os-locale](https://www.npmjs.com/package/os-locale)) so that
+yargs-generated help content will display in the user's language.
+
+To override this behavior with a static locale, pass the desired locale as a
+string to this method (see below).
+
 .locale(locale)
 ---------------
 
-Set a locale other than the operating system's default locale, you can modify this
-value by exporting `LC_ALL`.
+Override the auto-detected locale from the user's operating system with a static
+locale. Note that the OS locale can be modified by setting/exporting the `LC_ALL`
+environment variable.
 
 ```js
 var argv = require('yargs')
@@ -671,11 +684,6 @@ var argv = require('yargs')
   .locale('pirate')
   .argv
 ```
-
-.locale()
----------
-
-Return the locale that yargs has detected.
 
 ***
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var Completion = require('./lib/completion')
+var osLocale = require('os-locale')
 var Parser = require('./lib/parser')
 var path = require('path')
 var Usage = require('./lib/usage')
@@ -18,7 +19,7 @@ function Argv (processArgs, cwd) {
   var validation = null
   var y18n = Y18n({
     directory: path.resolve(__dirname, './locales'),
-    locale: 'en',
+    locale: guessLocale(),
     updateFiles: false
   })
 
@@ -405,6 +406,7 @@ function Argv (processArgs, cwd) {
   }
 
   self.locale = function (locale) {
+    if (arguments.length === 0) return y18n.getLocale()
     y18n.setLocale(locale)
     return self
   }
@@ -531,6 +533,10 @@ function Argv (processArgs, cwd) {
     Object.keys(options.key).forEach(function (key) {
       if (typeof argv[key] === 'undefined') argv[key] = undefined
     })
+  }
+
+  function guessLocale () {
+    return osLocale.sync().split('_')[0]
   }
 
   sigletonify(self)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function Argv (processArgs, cwd) {
   var validation = null
   var y18n = Y18n({
     directory: path.resolve(__dirname, './locales'),
-    locale: guessLocale(),
+    locale: osLocale.sync(),
     updateFiles: false
   })
 
@@ -533,10 +533,6 @@ function Argv (processArgs, cwd) {
     Object.keys(options.key).forEach(function (key) {
       if (typeof argv[key] === 'undefined') argv[key] = undefined
     })
-  }
-
-  function guessLocale () {
-    return osLocale.sync()
   }
 
   sigletonify(self)

--- a/index.js
+++ b/index.js
@@ -536,7 +536,7 @@ function Argv (processArgs, cwd) {
   }
 
   function guessLocale () {
-    return osLocale.sync().split('_')[0]
+    return osLocale.sync()
   }
 
   sigletonify(self)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -173,12 +173,12 @@ module.exports = function (yargs, y18n) {
         if (~options.array.indexOf(key)) type = '[' + __('array') + ']'
 
         var extra = [
-            type,
-            demanded[key] ? '[' + __('required') + ']' : null,
-            options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
-              self.stringifiedValues(options.choices[key]) + ']' : null,
-            defaultString(options.default[key], options.defaultDescription[key])
-          ].filter(Boolean).join(' ')
+          type,
+          demanded[key] ? '[' + __('required') + ']' : null,
+          options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
+            self.stringifiedValues(options.choices[key]) + ']' : null,
+          defaultString(options.default[key], options.defaultDescription[key])
+        ].filter(Boolean).join(' ')
 
         ui.span(
           {text: kswitch, padding: [0, 2, 0, 2], width: maxWidth(switches) + 4},

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "camelcase": "^1.0.2",
     "cliui": "^2.1.0",
     "decamelize": "^1.0.0",
+    "os-locale": "^1.2.0",
     "window-size": "^0.1.1",
     "y18n": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "decamelize": "^1.0.0",
     "os-locale": "^1.2.0",
     "window-size": "^0.1.1",
-    "y18n": "^3.0.0"
+    "y18n": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "coveralls": "^2.11.2",
+    "coveralls": "^2.11.4",
     "hashish": "0.0.4",
     "mocha": "^2.2.1",
     "nyc": "^3.1.0",
-    "standard": "^5.0.2"
+    "standard": "^5.1.0"
   },
   "scripts": {
     "test": "standard && nyc mocha --check-leaks",

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -311,21 +311,17 @@ describe('yargs dsl tests', function () {
   })
 
   describe('locale', function () {
-    it('returns locale if locale is called with no arguments', function () {
-      yargs.locale().should.equal('en')
-    })
-
     it("detects the operating system's locale", function () {
       loadLocale('es_ES.UTF-8')
-      yargs.locale().should.equal('es')
-      loadLocale('en_EN.UTF-8')
+      yargs.locale().should.equal('es_ES')
+      loadLocale('en_US.UTF-8')
     })
 
     it("it allows the operating system's locale to be overridden", function () {
       loadLocale('es_ES.UTF-8')
       yargs.locale('en')
       yargs.locale().should.equal('en')
-      loadLocale('en_EN.UTF-8')
+      loadLocale('en_US.UTF-8')
     })
 
     function loadLocale (locale) {
@@ -359,8 +355,8 @@ describe('yargs dsl tests', function () {
           .argv
       })
 
-      yargs.locale().should.equal('zz')
-      loadLocale('en_EN.UTF-8')
+      yargs.locale().should.equal('zz_ZZ')
+      loadLocale('en_US.UTF-8')
       r.logs.join(' ').should.match(/Commands:/)
     })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -311,6 +311,30 @@ describe('yargs dsl tests', function () {
   })
 
   describe('locale', function () {
+    it('returns locale if locale is called with no arguments', function () {
+      yargs.locale().should.equal('en')
+    })
+
+    it("detects the operating system's locale", function () {
+      loadLocale('es_ES.UTF-8')
+      yargs.locale().should.equal('es')
+      loadLocale('en_EN.UTF-8')
+    })
+
+    it("it allows the operating system's locale to be overridden", function () {
+      loadLocale('es_ES.UTF-8')
+      yargs.locale('en')
+      yargs.locale().should.equal('en')
+      loadLocale('en_EN.UTF-8')
+    })
+
+    function loadLocale (locale) {
+      process.env.LC_ALL = locale
+      delete require.cache[require.resolve('../')]
+      delete require.cache[require.resolve('os-locale')]
+      yargs = require('../')
+    }
+
     it("allows a locale other than the default 'en' to be specified", function () {
       var r = checkOutput(function () {
         yargs(['snuh', '-h'])
@@ -322,6 +346,22 @@ describe('yargs dsl tests', function () {
       })
 
       r.logs.join(' ').should.match(/Choose yer command:/)
+    })
+
+    it('handles a missing locale', function () {
+      loadLocale('zz_ZZ.UTF-8')
+
+      var r = checkOutput(function () {
+        yargs(['snuh', '-h'])
+          .command('blerg', 'blerg command')
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      yargs.locale().should.equal('zz')
+      loadLocale('en_EN.UTF-8')
+      r.logs.join(' ').should.match(/Commands:/)
     })
 
     it('uses locale string for help option default desc on .locale().help()', function () {


### PR DESCRIPTION
This pull moves us to phase 2.0 of locales in yargs, we now automatically detect the operating system's locale using @sindresorhus' [os-locale](https://github.com/sindresorhus/os-locale) module.

```sh
LC_ALL=pt_BR ./test.js --help
```

outputs:

```sh
Opções:
  -h, --help  Mostra ajuda                                             [boolean]
  --foo       what up fool                                          [padrão: 99]
  --config    i be config yo                             [padrão: "./cool.json"]
  -x                                                                [padrão: 10]
```

now we just need to work on getting some more translations.

reviewers: @nexdrew, @nylen