### PR TITLE
Added German translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Ye be havin' to set the followin' argument land lubber: option
 
 Locales currently supported:
 
+* **de:** German.
 * **en:** American English.
 * **es:** Spanish.
 * **fr:** French.

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -173,12 +173,12 @@ module.exports = function (yargs, y18n) {
         if (~options.array.indexOf(key)) type = '[' + __('array') + ']'
 
         var extra = [
-            type,
-            demanded[key] ? '[' + __('required') + ']' : null,
-            options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
-              self.stringifiedValues(options.choices[key]) + ']' : null,
-            defaultString(options.default[key], options.defaultDescription[key])
-          ].filter(Boolean).join(' ')
+          type,
+          demanded[key] ? '[' + __('required') + ']' : null,
+          options.choices && options.choices[key] ? '[' + __('choices:') + ' ' +
+            self.stringifiedValues(options.choices[key]) + ']' : null,
+          defaultString(options.default[key], options.defaultDescription[key])
+        ].filter(Boolean).join(' ')
 
         ui.span(
           {text: kswitch, padding: [0, 2, 0, 2], width: maxWidth(switches) + 4},

--- a/locales/de.json
+++ b/locales/de.json
@@ -3,7 +3,7 @@
   "Options:": "Optionen:",
   "Examples:": "Beispiele:",
   "boolean": "boolean",
-  "count": "count",
+  "count": "Zähler",
   "string": "string",
   "array": "array",
   "required": "erforderlich",

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,36 @@
+{
+  "Commands:": "Kommandos:",
+  "Options:": "Optionen:",
+  "Examples:": "Beispiele:",
+  "boolean": "boolean",
+  "count": "count",
+  "string": "string",
+  "array": "array",
+  "required": "erforderlich",
+  "default:": "Standard:",
+  "choices:": "Möglichkeiten:",
+  "generated-value": "Generierter-Wert",
+  "Not enough non-option arguments: got %s, need at least %s": "Nicht genügend Argumente ohne Optionen: %s vorhanden, mindestens %s benötigt",
+  "Too many non-option arguments: got %s, maximum of %s": "Zu viele Argumente ohne Optionen: %s vorhanden, maximal %s erlaubt",
+  "Missing argument value: %s": {
+    "one": "Fehlender Argumentwert: %s",
+    "other": "Fehlende Argumentwerte: %s"
+  },
+  "Missing required argument: %s": {
+    "one": "Fehlendes Argument: %s",
+    "other": "Fehlende Argumente: %s"
+  },
+  "Unknown argument: %s": {
+    "one": "Unbekanntes Argument: %s",
+    "other": "Unbekannte Argumente: %s"
+  },
+  "Invalid values:": "Unzulässige Werte:",
+  "Argument: %s, Given: %s, Choices: %s": "Argument: %s, Gegeben: %s, Möglichkeiten: %s",
+  "Argument check failed: %s": "Argumente-Check fehlgeschlagen: %s",
+  "Implications failed:": "Implikationen fehlgeschlagen:",
+  "Not enough arguments following: %s": "Nicht genügend Argumente nach: %s",
+  "Invalid JSON config file: %s": "Fehlerhafte JSON-Config Datei: %s",
+  "Path to JSON config file": "Pfad zur JSON-Config Datei",
+  "Show help": "Hilfe anzeigen",
+  "Show version number": "Version anzeigen"
+}


### PR DESCRIPTION
This adds German translation as said in the title.

Note: `array`, `string` and `boolean` are untouched because translating them to German rather causes confusion than enlightenment as I experienced it, I think that more people know the English words instead of the German words (if you still want me to translate them, tell me).

`count` is untouched because I'm not certain if I am aware of the context it's used in as I'm not having much experience with this module, could you provide an example? I'll fix it then.