### PR TITLE
Add defaultDescription to option()

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,11 +153,11 @@ function Argv (processArgs, cwd) {
         self.default(k, key[k])
       })
     } else {
+      if (defaultDescription) options.defaultDescription[key] = defaultDescription
       if (typeof value === 'function') {
-        defaultDescription = usage.functionDescription(value, defaultDescription)
+        if (!options.defaultDescription[key]) options.defaultDescription[key] = usage.functionDescription(value)
         value = value.call()
       }
-      options.defaultDescription[key] = defaultDescription
       options.default[key] = value
     }
     return self
@@ -296,6 +296,8 @@ function Argv (processArgs, cwd) {
         if (opt.alias) self.string(opt.alias)
       } if (opt.count || opt.type === 'count') {
         self.count(key)
+      } if (opt.defaultDescription) {
+        options.defaultDescription[key] = opt.defaultDescription
       }
 
       var desc = opt.describe || opt.description || opt.desc

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -271,10 +271,7 @@ module.exports = function (yargs, y18n) {
     console[level](self.help())
   }
 
-  self.functionDescription = function (fn, defaultDescription) {
-    if (defaultDescription) {
-      return defaultDescription
-    }
+  self.functionDescription = function (fn) {
     var description = fn.name ? decamelize(fn.name, '-') : __('generated-value')
     return ['(', description, ')'].join('')
   }
@@ -299,7 +296,7 @@ module.exports = function (yargs, y18n) {
   function defaultString (value, defaultDescription) {
     var string = '[' + __('default:') + ' '
 
-    if (value === undefined) return null
+    if (value === undefined && !defaultDescription) return null
 
     if (defaultDescription) {
       string += defaultDescription

--- a/test/usage.js
+++ b/test/usage.js
@@ -1124,6 +1124,111 @@ describe('usage tests', function () {
     })
   })
 
+  describe('defaultDescription', function () {
+    describe('using option() without default()', function () {
+      it('should output given desc with default value', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: '80 for HTTP and 443 for HTTPS',
+              default: 80
+            })
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
+      })
+
+      it('should output given desc without default value', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: '80 for HTTP and 443 for HTTPS'
+            })
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
+      })
+
+      it('should prefer given desc over function desc', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: '80 for HTTP and 443 for HTTPS',
+              default: function determinePort () {
+                return 80
+              }
+            })
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
+      })
+    })
+
+    describe('using option() with default()', function () {
+      it('should prefer default() desc when given last', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: 'depends on protocol'
+            })
+            .default('port', null, '80 for HTTP and 443 for HTTPS')
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
+      })
+
+      it('should prefer option() desc when given last', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .default('port', null, '80 for HTTP and 443 for HTTPS')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: 'depends on protocol'
+            })
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: depends on protocol')
+      })
+
+      it('should prefer option() desc over default() function', function () {
+        var r = checkUsage(function () {
+          return yargs(['-h'])
+            .help('h')
+            .option('port', {
+              describe: 'The port value for URL',
+              defaultDescription: '80 for HTTP and 443 for HTTPS'
+            })
+            .default('port', function determinePort () {
+              return 80
+            })
+            .wrap(null)
+            .argv
+        })
+
+        r.logs[0].should.include('default: 80 for HTTP and 443 for HTTPS')
+      })
+    })
+  })
+
   describe('normalizeAliases', function () {
     // see #128
     it("should display 'description' string in help message if set for alias", function () {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -110,6 +110,18 @@ describe('yargs dsl tests', function () {
     argv.looks.should.eql('good')
   })
 
+  it('should allow defaultDescription to be set with .option()', function () {
+    var optDefaultDescriptions = yargs([])
+      .option('port', {
+        defaultDescription: '80 for HTTP and 443 for HTTPS'
+      })
+      .getOptions().defaultDescription
+
+    optDefaultDescriptions.should.deep.equal({
+      port: '80 for HTTP and 443 for HTTPS'
+    })
+  })
+
   describe('showHelpOnFail', function () {
     it('should display custom failure message, if string is provided as first argument', function () {
       var r = checkOutput(function () {


### PR DESCRIPTION
This should fix issues #140 (excluding dot notation problems) and #194.

With this change, you can now do the following:

##### Example from 140
```js
var argv = require('yargs')
  .option('port', {
    defaultDescription: '80 for HTTP and 443 for HTTPS',
    default: null || undefined
  })
  .argv
```

##### Example from 194

```js
var argv = require('yargs')
  .option('id', {
    alias: 'name',
    type: 'string',
    default: require('moniker').choose,
    defaultDescription: 'moniker',
    describe: 'The log stream id'
  })
  .argv
```

And yargs help content will include `[default: 80 for HTTP and 443 for HTTPS]` and `[default: moniker]`, respectively.

Note that I slightly refactored the `default()` method to use this order of precedence for `defaultDescription`:

1. given `defaultDescription` argument
2. predefined `options.defaultDescription[key]` (via `option()`)
3. function description
4. (default value)

Not sure if I went overboard with the unit tests, but I think they all represent different valid scenarios. In fact, I probably could've written twice as many but tried to keep it minimal.