### PR TITLE
pass argv as a second argument to command handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,14 @@ Hidden commands don't show up in the help output and aren't available for
 completion.
 
 Optionally, you can provide a handler `fn` which will be executed when
-a given command is provided. The handler will be executed with an instance
-of `yargs`, which can be used to compose nested commands.
+a given command is provided. The handler will be called with `yargs` and
+`argv` as arguments.
+
+`yargs` is a blank instance of yargs, which can be used to compose a nested
+hierarchy of options handlers.
+
+`argv` represents the arguments parsed prior to the
+command being executed (those described in the outer yargs instance).
 
 Here's an example of top-level and nested commands in action:
 
@@ -472,7 +478,7 @@ Here's an example of top-level and nested commands in action:
 var argv = require('yargs')
   .usage('npm <command>')
   .command('install', 'tis a mighty fine package to install')
-  .command('publish', 'shiver me timbers, should you be sharing all that', function (yargs) {
+  .command('publish', 'shiver me timbers, should you be sharing all that', function (yargs, argv) {
     argv = yargs.option('f', {
       alias: 'force',
       description: 'yar, it usually be a bad idea'

--- a/index.js
+++ b/index.js
@@ -510,7 +510,7 @@ function Argv (processArgs, cwd) {
     var handlerKeys = Object.keys(self.getCommandHandlers())
     for (var i = 0, command; (command = handlerKeys[i]) !== undefined; i++) {
       if (~argv._.indexOf(command)) {
-        self.getCommandHandlers()[command](self.reset())
+        runCommand(command, self, argv)
         return self.argv
       }
     }
@@ -590,6 +590,11 @@ function Argv (processArgs, cwd) {
       // if we explode looking up locale just noop
       // we'll keep using the default language 'en'.
     }
+  }
+
+  function runCommand (command, yargs, argv) {
+    setPlaceholderKeys(argv)
+    yargs.getCommandHandlers()[command](yargs.reset(), argv)
   }
 
   function setPlaceholderKeys (argv) {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -38,6 +38,17 @@ describe('yargs dsl tests', function () {
     Object.keys(argv).should.include('cool')
   })
 
+  it('populates argv with placeholder keys when passed into command handler', function (done) {
+    yargs(['blerg'])
+      .option('cool', {})
+      .command('blerg', 'handle blerg things', function (yargs, argv) {
+        Object.keys(argv).should.include('cool')
+        return done()
+      })
+      .exitProcess(false) // defaults to true.
+      .argv
+  })
+
   it('accepts an object for implies', function () {
     var r = checkOutput(function () {
       return yargs(['--x=33'])
@@ -235,7 +246,12 @@ describe('yargs dsl tests', function () {
   describe('command', function () {
     it('allows a function to be associated with a command', function (done) {
       yargs(['blerg'])
-        .command('blerg', 'handle blerg things', function () {
+        .command('blerg', 'handle blerg things', function (yargs, argv) {
+          // a fresh yargs instance for perorming command-specific parsing,
+          // and an argv instance containing the parsing performed thus far
+          // should be passed to the command handler.
+          (typeof yargs.option).should.equal('function')
+          argv._[0].should.equal('blerg')
           return done()
         })
         .exitProcess(false) // defaults to true.

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -251,7 +251,11 @@ describe('yargs dsl tests', function () {
           // and an argv instance containing the parsing performed thus far
           // should be passed to the command handler.
           (typeof yargs.option).should.equal('function')
+          // we should get the argv from the prior yargs.
           argv._[0].should.equal('blerg')
+
+          // the yargs instance has been reset.
+          yargs.getCommandHandlers().should.deep.equal({})
           return done()
         })
         .exitProcess(false) // defaults to true.

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -247,7 +247,7 @@ describe('yargs dsl tests', function () {
     it('allows a function to be associated with a command', function (done) {
       yargs(['blerg'])
         .command('blerg', 'handle blerg things', function (yargs, argv) {
-          // a fresh yargs instance for perorming command-specific parsing,
+          // a fresh yargs instance for performing command-specific parsing,
           // and an argv instance containing the parsing performed thus far
           // should be passed to the command handler.
           (typeof yargs.option).should.equal('function')


### PR DESCRIPTION
until we can sit down and start overhauling how the command functionality works (I think this will be what drives us to `yargs@4.x`), I think this might be a good stop-gap to make commands more useful.

If someone wants to use some top-level options in their command handlers, they can now do this by using the outer `argv` which is passed as the second argument to the command handler.

I found myself wanting this for a command line app I'm working on today.

What do you think of this @nexdrew, is it a worthwhile tweak?