### PR TITLE
hotfix for os-locale on some windows platforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function Argv (processArgs, cwd) {
   var validation = null
   var y18n = Y18n({
     directory: path.resolve(__dirname, './locales'),
-    locale: osLocale.sync(),
+    locale: guessLocale(),
     updateFiles: false
   })
 
@@ -529,6 +529,14 @@ function Argv (processArgs, cwd) {
     setPlaceholderKeys(argv)
 
     return argv
+  }
+
+  function guessLocale () {
+    try {
+      return osLocale.sync()
+    } catch (err) {
+      return 'en'
+    }
   }
 
   function setPlaceholderKeys (argv) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "camelcase": "^1.2.1",
     "cliui": "^2.1.0",
     "decamelize": "^1.0.0",
-    "os-locale": "^1.2.0",
+    "os-locale": "^1.2.1",
     "window-size": "^0.1.2",
     "y18n": "^3.1.0"
   },

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -372,6 +372,17 @@ describe('yargs dsl tests', function () {
       r.logs.join(' ').should.match(/Commands:/)
     })
 
+    // see https://github.com/atom/atom/issues/8559#issuecomment-135876279
+    it('handles os-locale throwing an exception', function () {
+      // make os-locale throw.
+      require.cache[require.resolve('os-locale')].exports.sync = function () {throw Error('an error!')}
+
+      delete require.cache[require.resolve('../')]
+      yargs = require('../')
+
+      yargs.locale().should.equal('en')
+    })
+
     it('uses locale string for help option default desc on .locale().help()', function () {
       var r = checkOutput(function () {
         yargs(['-h'])


### PR DESCRIPTION
If os-locale throws, we will now default to en when detecting locale.

CC: @sindresorhus, @kevinsawicki, @MatthewNewland