### PR TITLE
Upgrade standard to 5.2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,7 @@ function Argv (processArgs, cwd) {
       // bin file with #!/usr/bin/env node
       if (i === 0 && /\b(node|iojs)$/.test(x)) return
       var b = rebase(cwd, x)
-      return x.match(/^\//) && b.length < x.length
-      ? b : x
+      return x.match(/^\//) && b.length < x.length ? b : x
     })
     .join(' ').trim()
 
@@ -580,9 +579,7 @@ function sigletonify (inst) {
     if (key === 'argv') {
       Argv.__defineGetter__(key, inst.__lookupGetter__(key))
     } else {
-      Argv[key] = typeof inst[key] === 'function'
-      ? inst[key].bind(inst)
-      : inst[key]
+      Argv[key] = typeof inst[key] === 'function' ? inst[key].bind(inst) : inst[key]
     }
   })
 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -304,8 +304,7 @@ module.exports = function (args, opts, y18n) {
           })
 
           argv.__defineGetter__(key, function () {
-            return typeof val === 'string' ?
-            path.normalize(val) : val
+            return typeof val === 'string' ? path.normalize(val) : val
           })
         })
         break

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hashish": "0.0.4",
     "mocha": "^2.3.0",
     "nyc": "^3.1.0",
-    "standard": "^5.2.0"
+    "standard": "^5.2.1"
   },
   "scripts": {
     "test": "standard && nyc mocha --timeout=4000 --check-leaks",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hashish": "0.0.4",
     "mocha": "^2.3.0",
     "nyc": "^3.1.0",
-    "standard": "^5.1.1"
+    "standard": "^5.2.0"
   },
   "scripts": {
     "test": "standard && nyc mocha --timeout=4000 --check-leaks",

--- a/test/integration.js
+++ b/test/integration.js
@@ -37,7 +37,6 @@ describe('integration tests', function () {
       })
       this.which.stderr.on('data', done)
     })
-
   })
 
   // see #177

--- a/test/usage.js
+++ b/test/usage.js
@@ -346,7 +346,6 @@ describe('usage tests', function () {
       .default('bar', 6)
       .default('baz', 7)
       .argv
-
     })
     r.should.have.property('result')
     r.result.should.have.property('foo', 50)
@@ -362,7 +361,6 @@ describe('usage tests', function () {
       .alias('f', 'foo')
       .default('f', 5)
       .argv
-
     })
     r.should.have.property('result')
     r.result.should.have.property('f', 5)
@@ -391,7 +389,6 @@ describe('usage tests', function () {
       return yargs('--foo 50 --baz 70'.split(' '))
       .default({ foo: 10, bar: 20, quux: 30 })
       .argv
-
     })
     r.should.have.property('result')
     r.result.should.have.property('_').with.length(0)


### PR DESCRIPTION
Required fixing the following nits:

- yargs/index.js:35:8: '?' should be placed at the end of the line.
- yargs/index.js:584:8: '?' should be placed at the end of the line.
- yargs/index.js:585:8: ':' should be placed at the end of the line.
- yargs/test/integration.js:41:4: Block must not be padded by blank lines.
- yargs/test/usage.js:350:6: Block must not be padded by blank lines.
- yargs/test/usage.js:366:6: Block must not be padded by blank lines.
- yargs/test/usage.js:395:6: Block must not be padded by blank lines.

These fixes would be required on next build anyway, according to current `devDependencies` semver range.