### PR TITLE
Migrate to new Travis container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language:
 os:
   - linux
   - osx
+sudo: false
 install:
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm


### PR DESCRIPTION
Noticed that recent Travis builds included a notice about running on legacy infrastructure. According to [the migration docs](http://docs.travis-ci.com/user/migrating-from-legacy/), moving to the new infrastructure is as easy as adding `sudo: false` to `.travis.yml`.

Let's give it a shot.

Again, expecting `standard` to fail until PR #247 is merged.