### PR TITLE
Fix order of locale environment variable

### DIFF
--- a/lib/locale.js
+++ b/lib/locale.js
@@ -6,7 +6,7 @@ module.exports = function () {
 
 function getEnvLocale () {
   var env = process.env
-  var ret = env.LC_ALL || env.LANGUAGE || env.LANG || env.LC_MESSAGES
+  var ret = env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE
   return getLocale(ret)
 }
 


### PR DESCRIPTION
During detection of the language to select translations the code is
[relying][2] on the same environment variables [libc][1]'s use, but
you are not considering them in the same order `glibc`
(and `gettext(3)`) do.

Specifically, you want to get the value of ``LC_MESSAGES`` locale
category (do not mistake here with the environment variable with the
same name).  To do that, the manual says:

    If locale is an empty string, "", each part of the locale that
    should be modified is set according to the environment variables.
    The details are implementation-dependent.  For glibc, first
    (regardless of category), the environment variable LC_ALL is
    inspected, next the environment variable with the same name as the
    category (see the table above), and finally the environment
    variable LANG.  The first existing environment variable is used.

Furthermore, ``LANGUAGE`` is a GNU extension to be used as a fallback
for all those.

Following the above, this patch fix the proper order of environment
variable selection to consider `LC_MESSAGES` before `LANG`, and put
`LANGUAGE` as the last option.


 [1]: http://manpages.ubuntu.com/manpages/hardy/man3/setlocale.3posix.html
 [2]: https://github.com/bcoe/yargs/blob/master/lib/locale.js#L9