### PR TITLE
Add Node v4.x to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script: npm test
 after_success: npm run coverage
 env:
   - NODE_VERSION="0.10"
-  - NODE_VERSION="0.11"
   - NODE_VERSION="0.12"
   - NODE_VERSION="iojs"
+  - NODE_VERSION="4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ environment:
   matrix:
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
-    - nodejs_version: "3.0"
+    - nodejs_version: "3"
+    - nodejs_version: "4"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "decamelize": "^1.0.0",
     "os-locale": "^1.4.0",
     "window-size": "^0.1.2",
-    "y18n": "^3.1.0"
+    "y18n": "^3.2.0"
   },
   "devDependencies": {
-    "chai": "^3.2.0",
+    "chai": "^3.3.0",
     "coveralls": "^2.11.4",
     "hashish": "0.0.4",
-    "mocha": "^2.3.2",
+    "mocha": "^2.3.3",
     "nyc": "^3.2.2",
-    "standard": "^5.3.0",
+    "standard": "^5.3.1",
     "which": "^1.1.2",
     "win-spawn": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "camelcase": "^1.2.1",
     "cliui": "^2.1.0",
     "decamelize": "^1.0.0",
-    "os-locale": "^1.3.1",
+    "os-locale": "^1.4.0",
     "window-size": "^0.1.2",
     "y18n": "^3.1.0"
   },
@@ -22,10 +22,10 @@
     "chai": "^3.2.0",
     "coveralls": "^2.11.4",
     "hashish": "0.0.4",
-    "mocha": "^2.3.0",
+    "mocha": "^2.3.2",
     "nyc": "^3.2.2",
-    "standard": "^5.2.1",
-    "which": "^1.1.1",
+    "standard": "^5.3.0",
+    "which": "^1.1.2",
     "win-spawn": "^2.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Also opted to drop Node v0.11, to keep number of builds the same (4 per platform) while still (theoretically) covering the same range (v0.10 - v4).

To make AppVeyor config consistent with Travis, also changed `3.0` to `3` to use latest iojs version (e.g. 3.3.1) instead of latest 3.0 version (which is always 3.0.0).

Note that, at least for Travis, we could use `stable` instead of `4` (to anticipate version 5+), but I decided to stick with prior convention.

Also note: I expect the build to fail (at the moment) for Node v0.10 until [issue 14 of `standard-engine`](https://github.com/Flet/standard-engine/issues/14) is fixed. Looks like we could revert our `standard` dependency back to version `5.0.0` to workaround this, but then we'd have to remember to update it once the `eslint` git dependency of `standard-engine` is fixed/removed.