### PR TITLE
Output failure message only once

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -28,17 +28,22 @@ module.exports = function (yargs, y18n) {
     return self
   }
 
+  var outputFailure = true
   self.fail = function (msg) {
     if (fails.length) {
       fails.forEach(function (f) {
         f(msg)
       })
     } else {
-      if (showHelpOnFail) yargs.showHelp('error')
-      if (msg) console.error(msg)
-      if (failMessage) {
-        if (msg) console.error('')
-        console.error(failMessage)
+      // don't output failure message more than once
+      if (outputFailure) {
+        outputFailure = false
+        if (showHelpOnFail) yargs.showHelp('error')
+        if (msg) console.error(msg)
+        if (failMessage) {
+          if (msg) console.error('')
+          console.error(failMessage)
+        }
       }
       if (yargs.getExitProcess()) {
         process.exit(1)

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -28,7 +28,7 @@ module.exports = function (yargs, y18n) {
     return self
   }
 
-  var outputFailure = true
+  var failureOutput = false
   self.fail = function (msg) {
     if (fails.length) {
       fails.forEach(function (f) {
@@ -36,8 +36,8 @@ module.exports = function (yargs, y18n) {
       })
     } else {
       // don't output failure message more than once
-      if (outputFailure) {
-        outputFailure = false
+      if (!failureOutput) {
+        failureOutput = true
         if (showHelpOnFail) yargs.showHelp('error')
         if (msg) console.error(msg)
         if (failMessage) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -285,6 +285,32 @@ describe('usage tests', function () {
     )
   })
 
+  describe('when exitProcess is false and check fails with a thrown exception', function () {
+    it('should display missing arguments once', function () {
+      var r = checkUsage(function () {
+        try {
+          return yargs('-x 10 -z 20'.split(' '))
+            .usage('Usage: $0 -x NUM -y NUM')
+            .exitProcess(false)
+            .wrap(null)
+            .check(function (argv) {
+              if (!('x' in argv)) throw Error('You forgot about -x')
+              if (!('y' in argv)) throw Error('You forgot about -y')
+            })
+            .argv
+        } catch (err) {
+          // ignore the error, we only test the output here
+        }
+      })
+      r.errors.join('\n').split(/\n+/).should.deep.equal([
+        'Usage: ./usage -x NUM -y NUM',
+        'You forgot about -y'
+      ])
+      r.should.have.property('logs').with.length(0)
+      r.should.have.property('exit').and.be.false
+    })
+  })
+
   it('should return a valid result when demanding a count of non-hyphenated values', function () {
     var r = checkUsage(function () {
       return yargs('1 2 3 --moo'.split(' '))

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -147,18 +147,34 @@ describe('yargs dsl tests', function () {
   })
 
   describe('exitProcess', function () {
-    it('throws an execption when a failure occurs, if exitProcess is set to false', function () {
-      checkOutput(function () {
-        expect(function () {
-          yargs([])
-            .demand('cat')
-            .showHelpOnFail(false)
-            .exitProcess(false)
-            .argv
-        }).to.throw(/Missing required argument/)
+    describe('when exitProcess is set to false and a failure occurs', function () {
+      it('should throw an exception', function () {
+        checkOutput(function () {
+          expect(function () {
+            yargs([])
+              .demand('cat')
+              .showHelpOnFail(false)
+              .exitProcess(false)
+              .argv
+          }).to.throw(/Missing required argument/)
+        })
+      })
+      it('should output the errors to stderr once', function () {
+        var r = checkOutput(function () {
+          try {
+            yargs([])
+              .demand('cat')
+              .showHelpOnFail(false)
+              .exitProcess(false)
+              .argv
+          } catch (err) {
+            // ignore the error, we only test the output here
+          }
+        })
+        expect(r.logs).to.deep.equal([])
+        expect(r.errors).to.deep.equal(['Missing required argument: cat'])
       })
     })
-
     it('should set exit process to true, if no argument provided', function () {
       var r = checkOutput(function () {
         return yargs([])


### PR DESCRIPTION
Fixes issue #270 (concerning when `.exitProcess(false)` is used) by implementing the simplest solution mentioned [in comment](https://github.com/bcoe/yargs/issues/270#issuecomment-144551525) there.

Includes and satisfies test specs from PR #269.