### PR TITLE
Find the config file in the nearest parent folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,7 +457,7 @@ function Argv (processArgs, cwd) {
   })
 
   function parseArgs (args) {
-    var parsed = Parser(args, options, y18n)
+    var parsed = Parser(args, options, y18n, cwd)
     var argv = parsed.argv
     var aliases = parsed.aliases
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,12 +2,13 @@
 // from minimist: https://www.npmjs.com/package/minimist
 var camelCase = require('camelcase')
 var path = require('path')
+var nearestSync = require('nearest-file-path').nearestSync
 
 function increment (orig) {
   return orig !== undefined ? orig + 1 : 0
 }
 
-module.exports = function (args, opts, y18n) {
+module.exports = function (args, opts, y18n, cwd) {
   if (!opts) opts = {}
 
   var __ = y18n.__
@@ -325,7 +326,8 @@ module.exports = function (args, opts, y18n) {
       var configPath = argv[configKey] || configLookup[configKey]
       if (configPath) {
         try {
-          var config = require(path.resolve(process.cwd(), configPath))
+          var nearestPath = nearestSync(configPath, cwd)
+          var config = require(nearestPath)
 
           Object.keys(config).forEach(function (key) {
             // setting arguments via CLI takes precedence over

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "camelcase": "^1.2.1",
     "cliui": "^3.0.2",
     "decamelize": "^1.0.0",
+    "nearest-file-path": "^1.1.0",
     "os-locale": "^1.4.0",
     "window-size": "^0.1.2",
     "y18n": "^3.2.0"

--- a/test/parser.js
+++ b/test/parser.js
@@ -370,6 +370,16 @@ describe('parser tests', function () {
       fail.should.equal(false)
     })
 
+    it('should look travel up parent directories until a config file is found', function () {
+      var childPath = path.resolve(__dirname, './fixtures/child')
+      var argv = yargs([], childPath)
+        .config('settings')
+        .default('settings', 'config.json')
+        .argv
+
+      argv.should.have.property('herp', 'derp')
+    })
+
     it('should be displayed in the help message', function () {
       var checkUsage = require('./helpers/utils').checkOutput
       var r = checkUsage(function () {


### PR DESCRIPTION
Travels up the folder hierarchy until a configuration file is found.
Same behaviour as npm, babel, jscs, jshint, etc.