### PR TITLE
fix dot notation parsing issues brought up in #279

### DIFF
--- a/index.js
+++ b/index.js
@@ -565,6 +565,9 @@ function Argv (processArgs, cwd) {
 
   function setPlaceholderKeys (argv) {
     Object.keys(options.key).forEach(function (key) {
+      // don't set placeholder keys for dot
+      // notation options 'foo.bar'.
+      if (key.match(/.*\..*/)) return
       if (typeof argv[key] === 'undefined') argv[key] = undefined
     })
   }

--- a/index.js
+++ b/index.js
@@ -567,7 +567,7 @@ function Argv (processArgs, cwd) {
     Object.keys(options.key).forEach(function (key) {
       // don't set placeholder keys for dot
       // notation options 'foo.bar'.
-      if (key.match(/.*\..*/)) return
+      if (~key.indexOf('.')) return
       if (typeof argv[key] === 'undefined') argv[key] = undefined
     })
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -281,6 +281,15 @@ module.exports = function (args, opts, y18n) {
     var splitKey = key.split('.')
     setKey(argv, splitKey, value)
 
+    // alias references an inner-value within
+    // a dot-notation object. see #279.
+    if (~key.indexOf('.') && aliases[key]) {
+      aliases[key].forEach(function (x) {
+        x = x.split('.')
+        setKey(argv, x, value)
+      })
+    }
+
     ;(aliases[splitKey[0]] || []).forEach(function (x) {
       x = x.split('.')
 
@@ -348,6 +357,7 @@ module.exports = function (args, opts, y18n) {
         setKey(obj, key.split('.'), defaults[key])
 
         ;(aliases[key] || []).forEach(function (x) {
+          if (hasKey(obj, x.split('.'))) return
           setKey(obj, x.split('.'), defaults[key])
         })
       }
@@ -361,7 +371,9 @@ module.exports = function (args, opts, y18n) {
     })
 
     var key = keys[keys.length - 1]
-    return key in o
+
+    if (typeof o !== 'object') return false
+    else return key in o
   }
 
   function setKey (obj, keys, value) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -419,9 +419,45 @@ describe('parser tests', function () {
 
     it('should apply defaults to dot notation arguments', function () {
       var argv = yargs([])
-      .default('foo.bar', 99)
-      .argv
+        .default('foo.bar', 99)
+        .argv
       argv.foo.bar.should.eql(99)
+    })
+
+    // see #279
+    it('should allow default to be overridden when an alias is provided', function () {
+      var argv = yargs(['--foo.bar', '200'])
+        .option('foo.bar', {
+          default: 99,
+          alias: 'f'
+        })
+        .argv
+
+      argv.foo.bar.should.eql(200)
+    })
+
+    // see #279
+    it('should also override alias', function () {
+      var argv = yargs(['--foo.bar', '200'])
+        .option('foo.bar', {
+          default: 99,
+          alias: 'f'
+        })
+        .argv
+
+      argv.f.should.eql(200)
+    })
+
+    // see #279
+    it('should not set an undefined dot notation key', function () {
+      var argv = yargs(['--foo.bar', '200'])
+        .option('foo.bar', {
+          default: 99,
+          alias: 'f'
+        })
+        .argv
+
+      ;('foo.bar' in argv).should.equal(false)
     })
 
     it('should respect .string() for dot notation arguments', function () {


### PR DESCRIPTION
fixes #279 addresses several parsing issues brought up by @mir3z in #279:

* an alias referencing an inner key was not respected (weird things happened like the inner object being turned into an array).
* an outer `foo.bar` key was being set by the `setPlaceholderKeys` method.
* an exception could be created by setting an object key equal to a non-object value.

I'd love an extra set of eyes on these changes, since it's always a bit frightening to muck with the guts of the yargs parser: CC: @mir3z, @nexdrew 