### PR TITLE
allow options to be placed in custom groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,18 +656,19 @@ Given a key, or an array of keys, places options under an alternative heading
 when displaying usage instructions, e.g.,
 
 ```js
-var yargs = require('./')(['--help'])
+var yargs = require('yargs')(['--help'])
   .help('help')
   .group('batman', 'Heroes:')
   .describe('batman', "world's greatest detective")
+  .wrap(null)
   .argv
 ```
 ***
-    Options:
-      --help  Show help  [boolean]
-
     Heroes:
       --batman  world's greatest detective
+
+    Options:
+      --help  Show help  [boolean]
 
 .help([option, [description]])
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -649,6 +649,27 @@ Method to execute when a failure occurs, rather than printing the failure messag
 
 `fn` is called with the failure message that would have been printed.
 
+<a name="group"></a>.group(key(s), groupName)
+--------------------
+
+Given a key, or an array of keys, places options under an alternative heading
+when displaying usage instructions, e.g.,
+
+***
+    Options:
+      --help  Show help  [boolean]
+
+    Heroes:
+      --batman  world's greatest detective
+
+```js
+var yargs = require('./')(['--help'])
+  .help('help')
+  .group('batman', 'Heroes:')
+  .describe('batman', "world's greatest detective")
+  .argv
+```
+
 .help([option, [description]])
 ------------------------------
 
@@ -827,6 +848,7 @@ Valid `opt` keys include:
 - `defaultDescription`: string, use this description for the default value in help content, see [`default()`](#default)
 - `demand`/`require`/`required`: boolean or string, demand the option be given, with optional error message, see [`demand()`](#demand)
 - `desc`/`describe`/`description`: string, the option description for help content, see [`describe()`](#describe)
+- `group`: string, when displaying usage instructions place the option under an alternative group heading, see [`group()`](#group)
 - `nargs`: number, specify how many arguments should be consumed for the option, see [`nargs()`](#nargs)
 - `requiresArg`: boolean, require the option be specified with a value, see [`requiresArg()`](#requiresArg)
 - `string`: boolean, interpret option as a string, see [`string()`](#string)

--- a/README.md
+++ b/README.md
@@ -655,13 +655,6 @@ Method to execute when a failure occurs, rather than printing the failure messag
 Given a key, or an array of keys, places options under an alternative heading
 when displaying usage instructions, e.g.,
 
-***
-    Options:
-      --help  Show help  [boolean]
-
-    Heroes:
-      --batman  world's greatest detective
-
 ```js
 var yargs = require('./')(['--help'])
   .help('help')
@@ -669,6 +662,12 @@ var yargs = require('./')(['--help'])
   .describe('batman', "world's greatest detective")
   .argv
 ```
+***
+    Options:
+      --help  Show help  [boolean]
+
+    Heroes:
+      --batman  world's greatest detective
 
 .help([option, [description]])
 ------------------------------

--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ function Argv (processArgs, cwd) {
     return options
   }
 
-  var groups = {'Options:': []}
+  var groups = {}
   self.group = function (opts, groupName) {
     groups[groupName] = (groups[groupName] || []).concat(opts)
     return self

--- a/index.js
+++ b/index.js
@@ -317,9 +317,7 @@ function Argv (processArgs, cwd) {
 
   var groups = {'Options:': []}
   self.group = function (opts, groupName) {
-    if (!Array.isArray(opts)) opts = [opts]
-    if (!groups[groupName]) groups[groupName] = []
-    Array.prototype.push.apply(groups[groupName], opts)
+    groups[groupName] = (groups[groupName] || []).concat(opts)
     return self
   }
   self.getGroups = function () {

--- a/index.js
+++ b/index.js
@@ -282,6 +282,8 @@ function Argv (processArgs, cwd) {
         self.nargs(key, opt.nargs)
       } if ('choices' in opt) {
         self.choices(key, opt.choices)
+      } if ('group' in opt) {
+        self.group(key, opt.group)
       } if (opt.boolean || opt.type === 'boolean') {
         self.boolean(key)
         if (opt.alias) self.boolean(opt.alias)
@@ -311,6 +313,17 @@ function Argv (processArgs, cwd) {
   }
   self.getOptions = function () {
     return options
+  }
+
+  var groups = {'Options:': []}
+  self.group = function (opts, groupName) {
+    if (!Array.isArray(opts)) opts = [opts]
+    if (!groups[groupName]) groups[groupName] = []
+    Array.prototype.push.apply(groups[groupName], opts)
+    return self
+  }
+  self.getGroups = function () {
+    return groups
   }
 
   self.wrap = function (cols) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -101,6 +101,7 @@ module.exports = function (yargs, y18n) {
     return deferY18nLookupPrefix + str
   }
 
+  var defaultGroup = 'Options:'
   self.help = function () {
     normalizeAliases()
 
@@ -155,6 +156,7 @@ module.exports = function (yargs, y18n) {
 
     // populate 'Options:' group with any keys that have not
     // explicitly had a group set.
+    if (!groups[defaultGroup]) groups[defaultGroup] = []
     addUngroupedKeys(keys, options.alias, groups)
 
     // display 'Options:' table along with any custom tables:
@@ -305,7 +307,7 @@ module.exports = function (yargs, y18n) {
       if (!toCheck.some(function (k) {
         return groupedKeys.indexOf(k) !== -1
       })) {
-        groups['Options:'].push(key)
+        groups[defaultGroup].push(key)
       }
     })
     return groupedKeys

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -296,12 +296,12 @@ module.exports = function (yargs, y18n) {
     var groupedKeys = []
     var toCheck = null
     Object.keys(groups).forEach(function (group) {
-      Array.prototype.push.apply(groupedKeys, groups[group])
+      groupedKeys = groupedKeys.concat(groups[group])
     })
 
     keys.forEach(function (key) {
       toCheck = [key]
-      Array.prototype.push.apply(toCheck, aliases[key])
+      toCheck = toCheck.concat(aliases[key])
       if (!toCheck.some(function (k) {
         return groupedKeys.indexOf(k) !== -1
       })) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -105,6 +105,7 @@ module.exports = function (yargs, y18n) {
     normalizeAliases()
 
     var demanded = yargs.getDemanded()
+    var groups = yargs.getGroups()
     var options = yargs.getOptions()
     var keys = Object.keys(
       Object.keys(descriptions)
@@ -141,7 +142,8 @@ module.exports = function (yargs, y18n) {
       ui.div()
     }
 
-    // the options table.
+    // perform some cleanup on the keys array, making it
+    // only include top-level keys not their aliases.
     var aliasKeys = (Object.keys(options.alias) || [])
       .concat(Object.keys(yargs.parsed.newAliases) || [])
 
@@ -151,20 +153,38 @@ module.exports = function (yargs, y18n) {
       })
     })
 
-    var switches = keys.reduce(function (acc, key) {
-      acc[key] = [ key ].concat(options.alias[key] || [])
-      .map(function (sw) {
-        return (sw.length > 1 ? '--' : '-') + sw
+    // populate 'Options:' group with any keys that have not
+    // explicitly had a group set.
+    addUngroupedKeys(keys, options.alias, groups)
+
+    // display 'Options:' table along with any custom tables:
+    Object.keys(groups).forEach(function (groupName) {
+      if (!groups[groupName].length) return
+
+      ui.div(__(groupName))
+
+      // if we've grouped the key 'f', but 'f' aliases 'foobar',
+      // normalizedKeys should contain only 'foobar'.
+      var normalizedKeys = groups[groupName].map(function (key) {
+        if (~aliasKeys.indexOf(key)) return key
+        for (var i = 0, aliasKey; (aliasKey = aliasKeys[i]) !== undefined; i++) {
+          if (~(options.alias[aliasKey] || []).indexOf(key)) return aliasKey
+        }
+        return key
       })
-      .join(', ')
 
-      return acc
-    }, {})
+      // actually generate the switches string --foo, -f, --bar.
+      var switches = normalizedKeys.reduce(function (acc, key) {
+        acc[key] = [ key ].concat(options.alias[key] || [])
+        .map(function (sw) {
+          return (sw.length > 1 ? '--' : '-') + sw
+        })
+        .join(', ')
 
-    if (keys.length) {
-      ui.div(__('Options:'))
+        return acc
+      }, {})
 
-      keys.forEach(function (key) {
+      normalizedKeys.forEach(function (key) {
         var kswitch = switches[key]
         var desc = descriptions[key] || ''
         var type = null
@@ -195,7 +215,7 @@ module.exports = function (yargs, y18n) {
       })
 
       ui.div()
-    }
+    })
 
     // describe some common use-cases for your application.
     if (examples.length) {
@@ -260,7 +280,6 @@ module.exports = function (yargs, y18n) {
         if (descriptions[alias]) self.describe(key, descriptions[alias])
         // copy demanded.
         if (demanded[alias]) yargs.demand(key, demanded[alias].msg)
-
         // type messages.
         if (~options.boolean.indexOf(alias)) yargs.boolean(key)
         if (~options.count.indexOf(alias)) yargs.count(key)
@@ -269,6 +288,27 @@ module.exports = function (yargs, y18n) {
         if (~options.array.indexOf(alias)) yargs.array(key)
       })
     })
+  }
+
+  // given a set of keys, place any keys that are
+  // ungrouped under the 'Options:' grouping.
+  function addUngroupedKeys (keys, aliases, groups) {
+    var groupedKeys = []
+    var toCheck = null
+    Object.keys(groups).forEach(function (group) {
+      Array.prototype.push.apply(groupedKeys, groups[group])
+    })
+
+    keys.forEach(function (key) {
+      toCheck = [key]
+      Array.prototype.push.apply(toCheck, aliases[key])
+      if (!toCheck.some(function (k) {
+        return groupedKeys.indexOf(k) !== -1
+      })) {
+        groups['Options:'].push(key)
+      }
+    })
+    return groupedKeys
   }
 
   self.showHelp = function (level) {

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -176,10 +176,10 @@ module.exports = function (yargs, y18n) {
       // actually generate the switches string --foo, -f, --bar.
       var switches = normalizedKeys.reduce(function (acc, key) {
         acc[key] = [ key ].concat(options.alias[key] || [])
-        .map(function (sw) {
-          return (sw.length > 1 ? '--' : '-') + sw
-        })
-        .join(', ')
+          .map(function (sw) {
+            return (sw.length > 1 ? '--' : '-') + sw
+          })
+          .join(', ')
 
         return acc
       }, {})

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -302,8 +302,7 @@ module.exports = function (yargs, y18n) {
     })
 
     keys.forEach(function (key) {
-      toCheck = [key]
-      toCheck = toCheck.concat(aliases[key])
+      toCheck = [key].concat(aliases[key])
       if (!toCheck.some(function (k) {
         return groupedKeys.indexOf(k) !== -1
       })) {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "dependencies": {
     "camelcase": "^1.2.1",
     "cliui": "^3.0.3",
-    "decamelize": "^1.0.0",
+    "decamelize": "^1.1.1",
     "os-locale": "^1.4.0",
     "window-size": "^0.1.2",
     "y18n": "^3.2.0"
   },
   "devDependencies": {
-    "chai": "^3.3.0",
+    "chai": "^3.4.1",
     "chalk": "^1.1.1",
     "coveralls": "^2.11.4",
     "es6-promise": "^3.0.2",

--- a/test/usage.js
+++ b/test/usage.js
@@ -1639,11 +1639,11 @@ describe('usage tests', function () {
       })
 
       r.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  --help  Show help  [boolean]',
-        '',
         'Heroes:',
         "  --batman  not the world's happiest guy  [string] [default: \"Bruce Wayne\"]",
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
         ''
       ])
     })
@@ -1696,11 +1696,11 @@ describe('usage tests', function () {
       })
 
       r.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  -h  Show help  [boolean]',
-        '',
         'Heroes:',
         '  --batman',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
         ''
       ])
     })
@@ -1709,6 +1709,7 @@ describe('usage tests', function () {
       var r = checkUsage(function () {
         return yargs(['-h'])
           .help('h')
+          .group('h', 'Options:')
           .group(['batman', 'robin'], 'Heroes:')
           .wrap(null)
           .argv
@@ -1738,11 +1739,11 @@ describe('usage tests', function () {
       })
 
       r.logs[0].split('\n').should.deep.equal([
-        'Options:',
-        '  -h  Show help  [boolean]',
-        '',
         'Heroes:',
         '  --batman  [string]',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
         ''
       ])
     })

--- a/test/usage.js
+++ b/test/usage.js
@@ -1622,4 +1622,129 @@ describe('usage tests', function () {
       r.logs.join(' ').should.match(/\[array\]/)
     })
   })
+
+  describe('group', function () {
+    it('allows an an option to be placed in an alternative group', function () {
+      var r = checkUsage(function () {
+        return yargs(['--help'])
+          .option('batman', {
+            type: 'string',
+            describe: "not the world's happiest guy",
+            default: 'Bruce Wayne'
+          })
+          .group('batman', 'Heroes:')
+          .help('help')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  --help  Show help  [boolean]',
+        '',
+        'Heroes:',
+        "  --batman  not the world's happiest guy  [string] [default: \"Bruce Wayne\"]",
+        ''
+      ])
+    })
+
+    it("does not print the 'Options:' group if no keys are in it", function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .string('batman')
+          .describe('batman', "not the world's happiest guy")
+          .default('batman', 'Bruce Wayne')
+          .group('batman', 'Heroes:')
+          .group('h', 'Heroes:')
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Heroes:',
+        "  --batman  not the world's happiest guy  [string] [default: \"Bruce Wayne\"]",
+        '  -h        Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('displays alias keys appropriately within a grouping', function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .help('help')
+          .alias('h', 'help')
+          .group('help', 'Magic Variable:')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Magic Variable:',
+        '  -h, --help  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('allows a group to be provided as the only information about an option', function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .help('h')
+          .group('batman', 'Heroes:')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  -h  Show help  [boolean]',
+        '',
+        'Heroes:',
+        '  --batman',
+        ''
+      ])
+    })
+
+    it('allows multiple options to be grouped at the same time', function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .help('h')
+          .group(['batman', 'robin'], 'Heroes:')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  -h  Show help  [boolean]',
+        '',
+        'Heroes:',
+        '  --batman',
+        '  --robin',
+        ''
+      ])
+    })
+
+    it('allows group to be provided in the options object', function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .help('h')
+          .option('batman', {
+            group: 'Heroes:',
+            string: true
+          })
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Options:',
+        '  -h  Show help  [boolean]',
+        '',
+        'Heroes:',
+        '  --batman  [string]',
+        ''
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Allow options to be placed in groups under headings other than the default `Options:` heading, like so:

```js
var yargs = require('yargs')(['--help'])
  .help('help')
  .group('batman', 'Heroes:')
  .describe('batman', "world's greatest detective")
  .argv
```

***
    Options:
          --help  Show help                                                    [boolean]

    Heroes:
      --batman  world's greatest detective

# Some Notes

This is a first pass at tackling #274, which proposes a solution that should help address several aggregate issues: #152, #260, #261 

I was originally trying out @nexdrew's suggestion in #274 of tacking parameters in the order `group, options` as I started writing tests, this felt too weird to me, as it deviated from other options -- it actually made me think we should clean up any other options that deviate in `yargs@4.x`, specifically `.version()`.