### PR TITLE
handle edge-cases when setting alias keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function Argv (processArgs, cwd) {
 
       // wait! perhaps we've created two lists of aliases
       // that reference each other?
-      if ((options.alias[x] || aliases) && options.alias[y]) {
+      if (options.alias[y]) {
         Array.prototype.push.apply((options.alias[x] || aliases), options.alias[y])
         delete options.alias[y]
       }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,25 @@ function Argv (processArgs, cwd) {
         self.alias(key, x[key])
       })
     } else {
-      options.alias[x] = (options.alias[x] || []).concat(y)
+      // perhaps 'x' is already an alias in another list?
+      // if so we should append to x's list.
+      var aliases = null
+      Object.keys(options.alias).forEach(function (key) {
+        if (~options.alias[key].indexOf(x)) aliases = options.alias[key]
+      })
+
+      if (aliases) { // x was an alias itself.
+        aliases.push(y)
+      } else { // x is a new alias key.
+        options.alias[x] = (options.alias[x] || []).concat(y)
+      }
+
+      // wait! perhaps we've created two lists of aliases
+      // that reference each other?
+      if ((options.alias[x] || aliases) && options.alias[y]) {
+        Array.prototype.push.apply((options.alias[x] || aliases), options.alias[y])
+        delete options.alias[y]
+      }
     }
     return self
   }

--- a/test/parser.js
+++ b/test/parser.js
@@ -399,6 +399,32 @@ describe('parser tests', function () {
     argv.should.have.property('f', 11)
   })
 
+  it('should allow transitive aliases to be specified', function () {
+    var argv = yargs([ '-f', '11', '--zoom', '55' ])
+      .alias('z', 'zm')
+      .alias('zm', 'zoom')
+      .argv
+
+    argv.should.have.property('zoom', 55)
+    argv.should.have.property('z', 55)
+    argv.should.have.property('zm', 55)
+    argv.should.have.property('f', 11)
+  })
+
+  it('should merge two lists of aliases if the collide', function () {
+    var argv = yargs([ '-f', '11', '--zoom', '55' ])
+      .alias('z', 'zm')
+      .alias('zoom', 'zoop')
+      .alias('zm', 'zoom')
+      .argv
+
+    argv.should.have.property('zoom', 55)
+    argv.should.have.property('zoop', 55)
+    argv.should.have.property('z', 55)
+    argv.should.have.property('zm', 55)
+    argv.should.have.property('f', 11)
+  })
+
   describe('dot notation', function () {
     it('should allow object graph traversal via dot notation', function () {
       var argv = yargs([

--- a/test/parser.js
+++ b/test/parser.js
@@ -411,7 +411,7 @@ describe('parser tests', function () {
     argv.should.have.property('f', 11)
   })
 
-  it('should merge two lists of aliases if the collide', function () {
+  it('should merge two lists of aliases if they collide', function () {
     var argv = yargs([ '-f', '11', '--zoom', '55' ])
       .alias('z', 'zm')
       .alias('zoom', 'zoop')


### PR DESCRIPTION
In the ongoing effort to make yargs unsinkable, this pull request handles edge-cases when setting aliases. This behavior used to fail:

```js
var argv = require('yargs')
  .alias('x', 'y')
  .alias('y', 'z')
```

As did this:

```js
var argv = require('yargs')
  .alias('z', 'zm')
  .alias('zoom', 'zoop')
  .alias('zm', 'zoom')
```

We're now clever about merging together alias groups as aliases are defined, solving these transitive edge-cases ... definitely an edge case, but I'm a bit OCD about making yargs handle every edge-case I think of!

reviewers: @nexdrew 