### PR TITLE
Changed "engine" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
   ],
   "license": "MIT",
   "engine": {
-    "node": ">=0.4"
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
Since the tests on travis are performed against Node 0.10 and higher, stating versions below 0.10 as compatible seems wrong. 