### PR TITLE
allow a custom parser to be passed to config()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Change Log
 
+### Upcoming
+
+- [#321](https://github.com/bcoe/yargs/pull/321) Custom config parsing function (@bcoe)
+
 ### v3.31.0 (2015/12/03 10:15 +07:00)
 
 - [#239](https://github.com/bcoe/yargs/pull/239) Pass argv to commands (@bcoe)

--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ Valid `opt` keys include:
 - `boolean`: boolean, interpret option as a boolean flag, see [`boolean()`](#boolean)
 - `choices`: value or array of values, limit valid option arguments to a predefined set, see [`choices()`](#choices)
 - `config`: boolean, interpret option as a path to a JSON config file, see [`config()`](#config)
+- `configParser`: function, provide a custom config parsing function, see [`config()`](#config)
 - `count`: boolean, interpret option as a count of boolean flags, see [`count()`](#count)
 - `default`: value, set a default value for the option, see [`default()`](#default)
 - `defaultDescription`: string, use this description for the default value in help content, see [`default()`](#default)

--- a/README.md
+++ b/README.md
@@ -549,17 +549,19 @@ var argv = require('yargs')
   .argv;
 ```
 
-<a name="config"></a>.config(key, [parseFn], [description])
+<a name="config"></a>.config(key, [description], [parseFn])
 ------------
 
 Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
-and parsed, and its properties are set as arguments. If present, the
-`description` parameter customizes the description of the config (`key`) option
+and parsed, and its properties are set as arguments.
+
+An optional `description` can be provided to customize of the config (`key`) option
 in the usage string.
 
-An optional `parseFn` argument can be passed to provide a custom config
-parser:
+An optional `parseFn` can be used to provide a custom parser. The parsing
+function must be synchronous, and should return an object containing
+key value pairs or an error.
 
 ```js
 var argv = require('yargs')

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Tells the parser that if the option specified by `key` is passed in, it
 should be interpreted as a path to a JSON config file. The file is loaded
 and parsed, and its properties are set as arguments.
 
-An optional `description` can be provided to customize of the config (`key`) option
+An optional `description` can be provided to customize the config (`key`) option
 in the usage string.
 
 An optional `parseFn` can be used to provide a custom parser. The parsing

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ var argv = require('yargs')
   .argv;
 ```
 
-<a name="config"></a>.config(key, [description])
+<a name="config"></a>.config(key, [parseFn], [description])
 ------------
 
 Tells the parser that if the option specified by `key` is passed in, it
@@ -557,6 +557,17 @@ should be interpreted as a path to a JSON config file. The file is loaded
 and parsed, and its properties are set as arguments. If present, the
 `description` parameter customizes the description of the config (`key`) option
 in the usage string.
+
+An optional `parseFn` argument can be passed to provide a custom config
+parser:
+
+```js
+var argv = require('yargs')
+  .config('settings', function (configPath) {
+    return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+  })
+  .argv
+```
 
 <a name="count"></a>.count(key)
 ------------

--- a/index.js
+++ b/index.js
@@ -116,10 +116,10 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.config = function (key, parseFn, msg) {
-    if (typeof parseFn === 'string') {
-      msg = parseFn
-      parseFn = null
+  self.config = function (key, msg, parseFn) {
+    if (typeof msg === 'function') {
+      parseFn = msg
+      msg = null
     }
     self.describe(key, msg || usage.deferY18nLookup('Path to JSON config file'))
     ;(Array.isArray(key) ? key : [key]).forEach(function (k) {

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function Argv (processArgs, cwd) {
       requiresArg: [],
       count: [],
       normalize: [],
-      config: [],
+      config: {},
       envPrefix: undefined
     }
 
@@ -116,9 +116,15 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.config = function (key, msg) {
+  self.config = function (key, parseFn, msg) {
+    if (typeof parseFn === 'string') {
+      msg = parseFn
+      parseFn = null
+    }
     self.describe(key, msg || usage.deferY18nLookup('Path to JSON config file'))
-    options.config.push.apply(options.config, [].concat(key))
+    ;(Array.isArray(key) ? key : [key]).forEach(function (k) {
+      options.config[k] = parseFn || true
+    })
     return self
   }
 

--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ function Argv (processArgs, cwd) {
       if (demand) {
         self.demand(key, demand)
       } if ('config' in opt) {
-        self.config(key)
+        self.config(key, opt.configParser)
       } if ('default' in opt) {
         self.default(key, opt.default)
       } if ('nargs' in opt) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -345,7 +345,11 @@ module.exports = function (args, opts, y18n) {
           var resolvedConfigPath = path.resolve(process.cwd(), configPath)
 
           if (typeof flags.configs[configKey] === 'function') {
-            config = flags.configs[configKey](resolvedConfigPath)
+            try {
+              config = flags.configs[configKey](resolvedConfigPath)
+            } catch (e) {
+              config = e
+            }
             if (config instanceof Error) {
               error = config
               return

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -346,6 +346,7 @@ module.exports = function (args, opts, y18n) {
 
           if (typeof flags.configs[configKey] === 'function') {
             config = flags.configs[configKey](resolvedConfigPath)
+            if (config instanceof Error) error = config
           } else {
             config = require(resolvedConfigPath)
           }
@@ -359,7 +360,7 @@ module.exports = function (args, opts, y18n) {
             }
           })
         } catch (ex) {
-          if (argv[configKey]) error = Error(__('Invalid config file (%s): %s', ex.message, configPath))
+          if (argv[configKey]) error = Error(__('Invalid JSON config file: %s', configPath))
         }
       }
     })

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -346,7 +346,10 @@ module.exports = function (args, opts, y18n) {
 
           if (typeof flags.configs[configKey] === 'function') {
             config = flags.configs[configKey](resolvedConfigPath)
-            if (config instanceof Error) error = config
+            if (config instanceof Error) {
+              error = config
+              return
+            }
           } else {
             config = require(resolvedConfigPath)
           }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -34,8 +34,8 @@ module.exports = function (args, opts, y18n) {
     flags.normalize[key] = true
   })
 
-  ;[].concat(opts.config).filter(Boolean).forEach(function (key) {
-    flags.configs[key] = true
+  Object.keys(opts.config).forEach(function (k) {
+    flags.configs[k] = opts.config[k]
   })
 
   var aliases = {}
@@ -341,7 +341,14 @@ module.exports = function (args, opts, y18n) {
       var configPath = argv[configKey] || configLookup[configKey]
       if (configPath) {
         try {
-          var config = require(path.resolve(process.cwd(), configPath))
+          var config = null
+          var resolvedConfigPath = path.resolve(process.cwd(), configPath)
+
+          if (typeof flags.configs[configKey] === 'function') {
+            config = flags.configs[configKey](resolvedConfigPath)
+          } else {
+            config = require(resolvedConfigPath)
+          }
 
           Object.keys(config).forEach(function (key) {
             // setting arguments via CLI takes precedence over
@@ -352,7 +359,7 @@ module.exports = function (args, opts, y18n) {
             }
           })
         } catch (ex) {
-          if (argv[configKey]) error = Error(__('Invalid JSON config file: %s', configPath))
+          if (argv[configKey]) error = Error(__('Invalid config file (%s): %s', ex.message, configPath))
         }
       }
     })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "win-spawn": "^2.0.0"
   },
   "scripts": {
-    "test": "standard && nyc ./node_modules/.bin/_mocha --timeout=4000 --check-leaks",
+    "pretest": "standard",
+    "test": "nyc ./node_modules/.bin/_mocha --timeout=4000 --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "es6-promise": "^3.0.2",
     "hashish": "0.0.4",
     "mocha": "^2.3.4",
-    "nyc": "^4.0.1",
+    "nyc": "^5.1.1",
     "standard": "^5.4.1",
     "which": "^1.1.2",
     "win-spawn": "^2.0.0"
   },
   "scripts": {
     "pretest": "standard",
-    "test": "nyc ./node_modules/.bin/_mocha --timeout=4000 --check-leaks",
+    "test": "nyc --cache ./node_modules/.bin/_mocha --timeout=4000 --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/test/fixtures/config.txt
+++ b/test/fixtures/config.txt
@@ -1,0 +1,2 @@
+AWESOME=banana
+BATMAN=grumpy

--- a/test/parser.js
+++ b/test/parser.js
@@ -349,7 +349,7 @@ describe('parser tests', function () {
         .alias('z', 'zoom')
         .config('settings')
         .fail(function (msg) {
-          msg.should.match(/Invalid config file (.*): fake\.json/)
+          msg.should.eql('Invalid JSON config file: fake.json')
           return done()
         })
         .argv
@@ -441,6 +441,26 @@ describe('parser tests', function () {
 
       argv.should.have.property('herp', 'derp')
       argv.should.have.property('foo', 'bar')
+    })
+
+    it('outputs an error returned by the parsing function', function () {
+      var checkUsage = require('./helpers/utils').checkOutput
+      var r = checkUsage(function () {
+        return yargs(['--settings=./package.json'])
+          .config('settings', 'path to config file', function (configPath) {
+            return Error('someone set us up the bomb')
+          })
+          .help('help')
+          .wrap(null)
+          .argv
+      })
+
+      r.errors.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  --settings  path to config file',
+        '  --help      Show help  [boolean]',
+        'someone set us up the bomb'
+      ])
     })
   })
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -231,7 +231,7 @@ describe('yargs dsl tests', function () {
         requiresArg: [],
         count: [],
         normalize: [],
-        config: [],
+        config: {},
         envPrefix: undefined
       }
 


### PR DESCRIPTION
Allow a custom parsing function to be passed to config.

Fixes #304 

Reviewers: @sebastienbarre, @indieisaconcept, @nexdrew 
