### PR TITLE
Make tests pass on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "pretest": "standard",
-    "test": "nyc --cache ./node_modules/.bin/_mocha --timeout=4000 --check-leaks",
+    "test": "nyc --cache mocha --timeout=4000 --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/test/parser.js
+++ b/test/parser.js
@@ -417,7 +417,7 @@ describe('parser tests', function () {
           // BATMAN=grumpy
           var config = {}
           var txt = fs.readFileSync(configPath, 'utf-8')
-          txt.split('\n').forEach(function (l) {
+          txt.split(/\r?\n/).forEach(function (l) {
             var kv = l.split('=')
             config[kv[0].toLowerCase()] = kv[1]
           })


### PR DESCRIPTION
Note: depends on https://github.com/bcoe/nyc/pull/123

Probably want to coordinate some releases.  Spawn-wrap and foreground-child are both sitting on a `next` dist-tag at the moment, and tap has a gnarly set of stuff on https://github.com/isaacs/node-tap/pull/204