### PR TITLE
Fix .version() API inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,12 +1120,13 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
-.version(version, [option], [description])
+.version([option], [description], version)
 ----------------------------------------
 
 Add an option (e.g. `--version`) that displays the version number (given by the
-`version` parameter) and exits the process. If present, the `description`
-parameter customizes the description of the version option in the usage string.
+`version` parameter) and exits the process. If no option is provided, it will default to `--version`.
+If present, the `description` parameter customizes the description of the version
+option in the usage string.
 
 You can provide a `function` for version, rather than a string.
 This is useful if you want to use the version from your package.json:

--- a/index.js
+++ b/index.js
@@ -378,11 +378,22 @@ function Argv (processArgs, cwd) {
   }
 
   var versionOpt = null
-  self.version = function (ver, opt, msg) {
-    versionOpt = opt || 'version'
-    usage.version(ver)
+  self.version = function (opt, msg, ver) {
+    if (arguments.length === 1) {
+      ver = opt
+      versionOpt = 'version'
+      msg = usage.deferY18nLookup('Show version number')
+    } else if (arguments.length === 2) {
+      versionOpt = opt
+      ver = msg
+      msg = usage.deferY18nLookup('Show version number')
+    } else {
+      versionOpt = opt
+    }
+
+    usage.version(ver || undefined)
     self.boolean(versionOpt)
-    self.describe(versionOpt, msg || usage.deferY18nLookup('Show version number'))
+    self.describe(versionOpt, msg)
     return self
   }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -370,7 +370,7 @@ module.exports = function (yargs, y18n) {
 
   // logic for displaying application version.
   var version = null
-  self.version = function (ver, opt, msg) {
+  self.version = function (ver) {
     version = ver
   }
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -862,7 +862,7 @@ describe('usage tests', function () {
     it('should display version', function () {
       var r = checkUsage(function () {
         return yargs(['--version'])
-        .version('1.0.1', 'version', 'Show version number')
+        .version('version', 'Show version number', '1.0.1')
         .wrap(null)
         .argv
       })
@@ -874,12 +874,22 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.1')
     })
 
+    it('accepts version option as first argument, and version number as second argument', function () {
+      var r = checkUsage(function () {
+        return yargs(['--version'])
+        .version('version', '1.0.0')
+        .wrap(null)
+        .argv
+      })
+      r.logs[0].should.eql('1.0.0')
+    })
+
     it('should allow a function to be provided, rather than a number', function () {
       var r = checkUsage(function () {
         return yargs(['--version'])
-        .version(function () {
+        .version('version', function () {
           return require('./fixtures/config').version
-        }, 'version')
+        })
         .wrap(null)
         .argv
       })
@@ -902,7 +912,7 @@ describe('usage tests', function () {
       it('should not validate arguments (required argument)', function () {
         var r = checkUsage(function () {
           return yargs(['--version'])
-            .version('1.0.1', 'version', 'Show version number')
+            .version('version', 'Show version number', '1.0.1')
             .demand('some-opt')
             .wrap(null)
             .exitProcess(false)
@@ -923,7 +933,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
           return yargs(['--version', '--some-opt'])
             .nargs('some-opt', 3)
-            .version('1.0.1', 'version', 'Show version number')
+            .version('version', 'Show version number', '1.0.1')
             .wrap(null)
             .exitProcess(false)
             .argv


### PR DESCRIPTION
This pull request changes the version() API to solve the inconsistency as raised by @bcoe in #329 