### PR TITLE
Default value for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,13 +1120,14 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
-.version([option], [description], version)
+.version([option], [description], [version])
 ----------------------------------------
 
 Add an option (e.g. `--version`) that displays the version number (given by the
 `version` parameter) and exits the process. If no option is provided, it will default to `--version`.
 If present, the `description` parameter customizes the description of the version
-option in the usage string.
+option in the usage string. You can also pass no `version` parameter (`.version()`),
+in this case, yargs will parse the `package.json` of your module and use its `version` value.
 
 You can provide a `function` for version, rather than a string.
 This is useful if you want to use the version from your package.json:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path')
 var Usage = require('./lib/usage')
 var Validation = require('./lib/validation')
 var Y18n = require('y18n')
+var readPkgUp = require('read-pkg-up')
 
 Argv(process.argv.slice(2))
 
@@ -379,17 +380,18 @@ function Argv (processArgs, cwd) {
 
   var versionOpt = null
   self.version = function (opt, msg, ver) {
-    if (arguments.length === 1) {
+    if (arguments.length === 0) {
+      ver = readPkgUp.sync({cwd: path.join(__dirname + '/..')}).pkg.version
+      opt = 'version'
+    } else if (arguments.length === 1) {
       ver = opt
-      versionOpt = 'version'
-      msg = usage.deferY18nLookup('Show version number')
+      opt = 'version'
     } else if (arguments.length === 2) {
-      versionOpt = opt
       ver = msg
-      msg = usage.deferY18nLookup('Show version number')
-    } else {
-      versionOpt = opt
     }
+
+    versionOpt = opt
+    msg = msg || usage.deferY18nLookup('Show version number')
 
     usage.version(ver || undefined)
     self.boolean(versionOpt)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "camelcase": "^2.0.1",
     "cliui": "^3.0.3",
     "decamelize": "^1.1.1",
+    "read-pkg-up": "^1.0.1",
     "os-locale": "^1.4.0",
     "string-width": "^1.0.1",
     "window-size": "^0.1.4",

--- a/test/usage.js
+++ b/test/usage.js
@@ -874,7 +874,7 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.1')
     })
 
-    it('defaults to the version # in the package.json', function () {
+    /*it('defaults to the version # in the package.json', function () {
       var r = checkUsage(function () {
         return yargs(['--version'])
         .version()
@@ -882,7 +882,7 @@ describe('usage tests', function () {
         .argv
       })
       r.logs[0].should.eql(require('./package.json').version)
-    })
+    })*/
 
     it('accepts version option as first argument, and version number as second argument', function () {
       var r = checkUsage(function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -874,6 +874,16 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.1')
     })
 
+    it('defaults to the version # in the package.json', function () {
+      var r = checkUsage(function () {
+        return yargs(['--version'])
+        .version()
+        .wrap(null)
+        .argv
+      })
+      r.logs[0].should.eql(require('./package.json').version)
+    })
+
     it('accepts version option as first argument, and version number as second argument', function () {
       var r = checkUsage(function () {
         return yargs(['--version'])


### PR DESCRIPTION
This PR adds a default value for the `version` parameter in `.version()`, making the parameter optional. In addition with #330 (this PR includes its commit), following ways of interacting with the API are possible:
```javascript
.version(opt, msg, ver)

.version(opt, ver)

.version(ver)

.version()
```
When no parameter is provided, [read-pkg-up](https://github.com/sindresorhus/read-pkg-up) is called to find the parent `package.json`, so the one of the module using yargs, parses its content, and uses the `version` value from there.

_Note_: Currently, there are no tests. I would like to get some ideas how to write the tests first.