### PR TITLE
Clear groups in reset method

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function Argv (processArgs, cwd) {
     completion = Completion(self, usage)
 
     demanded = {}
+    groups = {}
 
     exitProcess = true
     strict = false
@@ -342,7 +343,11 @@ function Argv (processArgs, cwd) {
 
   var groups = {}
   self.group = function (opts, groupName) {
-    groups[groupName] = (groups[groupName] || []).concat(opts)
+    var seen = {}
+    groups[groupName] = (groups[groupName] || []).concat(opts).filter(function (key) {
+      if (seen[key]) return false
+      return (seen[key] = true)
+    })
     return self
   }
   self.getGroups = function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1200,6 +1200,34 @@ describe('usage tests', function () {
         'Missing', 'required', 'argument:', 'y'
       ])
     })
+
+    it('resets groups for a command handler, respecting order', function () {
+      var r = checkUsage(function () {
+        return yargs(['upload', '-h'])
+          .command('upload', 'upload something', function (yargs, argv) {
+            argv = yargs
+              .option('q', {
+                type: 'boolean',
+                group: 'Flags:'
+              })
+              .help('h').group('h', 'Global Flags:')
+              .wrap(null)
+              .argv
+          })
+          .help('h').group('h', 'Global Flags:')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Flags:',
+        '  -q  [boolean]',
+        '',
+        'Global Flags:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
   })
 
   describe('epilogue', function () {
@@ -1741,6 +1769,30 @@ describe('usage tests', function () {
       r.logs[0].split('\n').should.deep.equal([
         'Heroes:',
         '  --batman  [string]',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('only displays a duplicated option once per group', function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .help('h')
+          .group(['batman', 'batman'], 'Heroes:')
+          .group('robin', 'Heroes:')
+          .option('robin', {
+            group: 'Heroes:'
+          })
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Heroes:',
+        '  --batman',
+        '  --robin',
         '',
         'Options:',
         '  -h  Show help  [boolean]',

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -213,6 +213,7 @@ describe('yargs dsl tests', function () {
         .string('foo')
         .choices('foo', ['bar', 'baz'])
         .implies('foo', 'snuh')
+        .group('foo', 'Group:')
         .strict()
         .exitProcess(false)  // defaults to true.
         .env('YARGS')
@@ -242,6 +243,7 @@ describe('yargs dsl tests', function () {
       expect(y.getStrict()).to.equal(false)
       expect(y.getDemanded()).to.deep.equal({})
       expect(y.getCommandHandlers()).to.deep.equal({})
+      expect(y.getGroups()).to.deep.equal({})
     })
   })
 


### PR DESCRIPTION
Fixes #336.

And make sure an option is added to a group only once.

First commit contains failing tests to demonstrate the problems.

Second commit fixes the failing tests.