### PR TITLE
removing cname from outdated repository

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-yargs.js.org


### PR DESCRIPTION
As per @nexdrew 's suggestions in yargs' [github.io](https://github.com/yargs/yargs.github.io/issues/1#issuecomment-168469258) discussion. :sparkles: 