### PR TITLE
default to the version we read in the package using yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,18 +1124,18 @@ present script similar to how `$0` works in bash or perl.
 ----------------------------------------
 
 Add an option (e.g. `--version`) that displays the version number (given by the
-`version` parameter) and exits the process. If no option is provided, it will default to `--version`.
-If present, the `description` parameter customizes the description of the version
-option in the usage string. You can also pass no `version` parameter (`.version()`),
-in this case, yargs will parse the `package.json` of your module and use its `version` value.
+`version` parameter) and exits the process.
+
+If no arguments are passed to `version` (`.version()`), yargs will parse the `package.json`
+of your module and use its `version` value. The default value of `option` is `--version`.
 
 You can provide a `function` for version, rather than a string.
-This is useful if you want to use the version from your package.json:
+This is useful if you want to use a version stored in a location other than package.json:
 
 ```js
 var argv = require('yargs')
   .version(function() {
-    return require('../package').version;
+    return require('../lib/version').version;
   })
   .argv;
 ```

--- a/README.md
+++ b/README.md
@@ -1120,13 +1120,14 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
-.version([option], [description], version)
+.version([option], [description], [version])
 ----------------------------------------
 
 Add an option (e.g. `--version`) that displays the version number (given by the
 `version` parameter) and exits the process. If no option is provided, it will default to `--version`.
 If present, the `description` parameter customizes the description of the version
-option in the usage string.
+option in the usage string. You can also pass no `version` parameter (`.version()`),
+in this case, yargs will parse the `package.json` of your module and use its `version` value.
 
 You can provide a `function` for version, rather than a string.
 This is useful if you want to use the version from your package.json:

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var path = require('path')
 var Usage = require('./lib/usage')
 var Validation = require('./lib/validation')
 var Y18n = require('y18n')
+var parent = require('parent-package-json')
 
 Argv(process.argv.slice(2))
 
@@ -379,17 +380,25 @@ function Argv (processArgs, cwd) {
 
   var versionOpt = null
   self.version = function (opt, msg, ver) {
-    if (arguments.length === 1) {
+    if (arguments.length === 0) {
+      ver = parent(__dirname)
+
+      if (ver === false) {
+        ver = undefined
+      } else {
+        ver = ver.parse().version
+      }
+
+      opt = 'version'
+    } else if (arguments.length === 1) {
       ver = opt
-      versionOpt = 'version'
-      msg = usage.deferY18nLookup('Show version number')
+      opt = 'version'
     } else if (arguments.length === 2) {
-      versionOpt = opt
       ver = msg
-      msg = usage.deferY18nLookup('Show version number')
-    } else {
-      versionOpt = opt
     }
+
+    versionOpt = opt
+    msg = msg || usage.deferY18nLookup('Show version number')
 
     usage.version(ver || undefined)
     self.boolean(versionOpt)

--- a/index.js
+++ b/index.js
@@ -404,11 +404,13 @@ function Argv (processArgs, cwd) {
       cwd: path.resolve(__dirname, '../')
     })
 
-    if (!obj) {
-      return obj
-    } else {
-      return obj.pkg.version
+    // fallback to process.cwd() this
+    // solves the case of symlinked modules.
+    if (!obj.pkg) {
+      obj = readPkgUp.sync()
     }
+
+    return obj.pkg ? obj.pkg.version : 'unknown'
   }
 
   var helpOpt = null

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var path = require('path')
 var Usage = require('./lib/usage')
 var Validation = require('./lib/validation')
 var Y18n = require('y18n')
-var parent = require('parent-package-json')
+var readPkgUp = require('read-pkg-up')
 
 Argv(process.argv.slice(2))
 
@@ -381,14 +381,7 @@ function Argv (processArgs, cwd) {
   var versionOpt = null
   self.version = function (opt, msg, ver) {
     if (arguments.length === 0) {
-      ver = parent(__dirname)
-
-      if (ver === false) {
-        ver = undefined
-      } else {
-        ver = ver.parse().version
-      }
-
+      ver = guessVersion()
       opt = 'version'
     } else if (arguments.length === 1) {
       ver = opt
@@ -404,6 +397,18 @@ function Argv (processArgs, cwd) {
     self.boolean(versionOpt)
     self.describe(versionOpt, msg)
     return self
+  }
+
+  function guessVersion () {
+    var obj = readPkgUp.sync({
+      cwd: path.resolve(__dirname, '../')
+    })
+
+    if (!obj) {
+      return obj
+    } else {
+      return obj.pkg.version
+    }
   }
 
   var helpOpt = null

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "camelcase": "^2.0.1",
     "cliui": "^3.0.3",
     "decamelize": "^1.1.1",
-    "parent-package-json": "^1.0.1",
     "os-locale": "^1.4.0",
+    "read-pkg-up": "^1.0.1",
     "string-width": "^1.0.1",
     "window-size": "^0.1.4",
     "y18n": "^3.2.0"
@@ -24,10 +24,12 @@
     "chai": "^3.4.1",
     "chalk": "^1.1.1",
     "coveralls": "^2.11.4",
+    "cpr": "^1.0.0",
     "es6-promise": "^3.0.2",
     "hashish": "0.0.4",
     "mocha": "^2.3.4",
     "nyc": "^5.2.0",
+    "rimraf": "^2.5.0",
     "standard": "^5.4.1",
     "which": "^1.1.2",
     "win-spawn": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "camelcase": "^2.0.1",
     "cliui": "^3.0.3",
     "decamelize": "^1.1.1",
+    "parent-package-json": "^1.0.1",
     "os-locale": "^1.4.0",
     "string-width": "^1.0.1",
     "window-size": "^0.1.4",

--- a/test/usage.js
+++ b/test/usage.js
@@ -886,6 +886,9 @@ describe('usage tests', function () {
         cpr('./', './test/fixtures/yargs', {
           filter: /node_modules|example|test|package\.json/
         }, function () {
+          fs.writeFileSync('./test/fixtures/yargs/package.json', JSON.stringify({
+            version: 99
+          }), 'utf-8')
           fs.symlinkSync(process.cwd(), './test/fixtures/yargs-symlink')
           return done()
         })

--- a/test/usage.js
+++ b/test/usage.js
@@ -874,6 +874,16 @@ describe('usage tests', function () {
       r.logs[0].should.eql('1.0.1')
     })
 
+    it('defaults to the version # in the package.json', function () {
+      var r = checkUsage(function () {
+        return yargs(['--version'])
+        .version()
+        .wrap(null)
+        .argv
+      })
+      r.logs[0].should.eql(require('./package.json').version)
+    })
+
     it('accepts version option as first argument, and version number as second argument', function () {
       var r = checkUsage(function () {
         return yargs(['--version'])


### PR DESCRIPTION
This is an update to @maxrimue's awesome work adding tests.

I found the test cases slightly tricky to simulate, I ended up:

1. copying the current yargs module to a fixtures directory so that I could test the normal behavior.
2. creating a symlink in the fixtures directory so that I could test the symlink behavior.

I would love thoughts from @sindresorhus, and @nexdrew as to how we might simply this testing logic.