### PR TITLE
Make yargs use English locales in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "pretest": "standard",
-    "test": "nyc --cache mocha --timeout=4000 --check-leaks",
+    "test": "nyc --cache mocha --require ./test/before.js --timeout=4000 --check-leaks",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {

--- a/test/before.js
+++ b/test/before.js
@@ -1,0 +1,1 @@
+process.env.LC_ALL = 'en_US'


### PR DESCRIPTION
This fixes a bug where the unit tests were expecting yargs' output to be in English, which means that tests, checking for equality with prewritten outputs in English, will fail on machines where yargs will detect and use another locale than English.