### PR TITLE
Remove changelog from published NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-.idea/
-node_modules/
-*.swp
-test.js
-coverage
-.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,7 @@
 CHANGELOG.md
-
+.idea/
+node_modules/
+*.swp
+test.js
+coverage
+.nyc_output


### PR DESCRIPTION
I'm thinking about using Yargs in a [super exciting project](https://www.npmjs.com/package/cash), but due to the nature of the project, performance and package size is a big issue.

Yargs unnecessarily publishes a 44kb changelog - *very* important on the Github repo, but not so much in a published module dependency.

Can we remove this please? You'll make many projects that much snappier. :smiley: 