### PR TITLE
fix .gitignore and rm .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea/
+node_modules/
+.nyc_output/
+*.swp

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-CHANGELOG.md
-.idea/
-node_modules/
-*.swp
-test.js
-coverage
-.nyc_output


### PR DESCRIPTION
Need to undo #354 since npm will always include `CHANGELOG` file according to https://docs.npmjs.com/misc/developers