### PR TITLE
require valid command

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,26 @@ instead of the standard error message. This is especially helpful for the non-op
 If a `boolean` value is given, it controls whether the option is demanded;
 this is useful when using `.options()` to specify command line parameters.
 
+A combination of `.demand(1)` and `.strict()` will allow you to require a user to pass at least one command:
+
+```js
+var argv = require('yargs')
+  .command('install', 'tis a mighty fine package to install')
+  .demand(1)
+  .strict()
+  .argv
+```
+
+Similarly, you can require a command and arguments at the same time:
+
+```js
+var argv = require('yargs')
+  .command('install', 'tis a mighty fine package to install')
+  .demand(1, ['w', 'm'])
+  .strict()
+  .argv
+```
+
 <a name="describe"></a>.describe(key, desc)
 --------------------
 

--- a/index.js
+++ b/index.js
@@ -208,7 +208,12 @@ function Argv (processArgs, cwd) {
     // you can optionally provide a 'max' key,
     // which will raise an exception if too many '_'
     // options are provided.
-    if (typeof max !== 'number') {
+
+    if (Array.isArray(max)) {
+      max.forEach(function (key) {
+        self.demand(key, msg)
+      })
+    } else if (typeof max !== 'number') {
       msg = max
       max = Infinity
     }
@@ -231,6 +236,7 @@ function Argv (processArgs, cwd) {
 
     return self
   }
+
   self.getDemanded = function () {
     return demanded
   }
@@ -662,4 +668,4 @@ function singletonify (inst) {
       Argv[key] = typeof inst[key] === 'function' ? inst[key].bind(inst) : inst[key]
     }
   })
-}
+

--- a/index.js
+++ b/index.js
@@ -669,3 +669,4 @@ function singletonify (inst) {
     }
   })
 
+}

--- a/index.js
+++ b/index.js
@@ -668,5 +668,4 @@ function singletonify (inst) {
       Argv[key] = typeof inst[key] === 'function' ? inst[key].bind(inst) : inst[key]
     }
   })
-
 }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -108,7 +108,6 @@ module.exports = function (yargs, usage, y18n) {
       if (key !== '$0' && key !== '_' &&
         !descriptions.hasOwnProperty(key) &&
         !demanded.hasOwnProperty(key) &&
-        !commandKeys.hasOwnProperty(key) &&
         !aliasLookup.hasOwnProperty(key)) {
         unknown.push(key)
       }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -114,6 +114,12 @@ module.exports = function (yargs, usage, y18n) {
       }
     })
 
+    argv._.forEach(function (key) {
+      if (!commandKeys.hasOwnProperty(key)) {
+        unknown.push(key)
+      }
+    })
+
     if (unknown.length > 0) {
       usage.fail(__n(
         'Unknown argument: %s',

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -95,6 +95,7 @@ module.exports = function (yargs, usage, y18n) {
     var aliasLookup = {}
     var descriptions = usage.getDescriptions()
     var demanded = yargs.getDemanded()
+    var commandKeys = Object.keys(yargs.getCommandHandlers())
     var unknown = []
 
     Object.keys(aliases).forEach(function (key) {
@@ -107,6 +108,7 @@ module.exports = function (yargs, usage, y18n) {
       if (key !== '$0' && key !== '_' &&
         !descriptions.hasOwnProperty(key) &&
         !demanded.hasOwnProperty(key) &&
+        !commandKeys.hasOwnProperty(key) &&
         !aliasLookup.hasOwnProperty(key)) {
         unknown.push(key)
       }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -95,7 +95,7 @@ module.exports = function (yargs, usage, y18n) {
     var aliasLookup = {}
     var descriptions = usage.getDescriptions()
     var demanded = yargs.getDemanded()
-    var commandKeys = Object.keys(yargs.getCommandHandlers())
+    var commandKeys = yargs.getCommandHandlers()
     var unknown = []
 
     Object.keys(aliases).forEach(function (key) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -36,6 +36,29 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
+      it('fails if one command and an argument not on the list are provided', function () {
+        var r = checkUsage(function () {
+          return yargs('wombat -w 10 -y 10')
+            .usage('Usage: $0 -w NUM -m NUM')
+            .demand(1, ['w', 'm'])
+            .strict()
+            .wrap(null)
+            .argv
+        })
+        r.result.should.have.property('w', 10)
+        r.result.should.have.property('y', 10)
+        r.result.should.have.property('_').with.length(1)
+        r.errors.join('\n').split(/\n+/).should.deep.equal([
+          'Usage: ./usage -w NUM -m NUM',
+          'Options:',
+          '  -w  [required]',
+          '  -m  [required]',
+          'Missing required argument: m'
+        ])
+        r.logs.should.have.length(0)
+        r.exit.should.be.ok
+      })
+
       describe('using .require()', function () {
         it('should show an error along with the missing arguments on demand fail', function () {
           var r = checkUsage(function () {
@@ -54,6 +77,28 @@ describe('usage tests', function () {
             '  -x  [required]',
             '  -y  [required]',
             'Missing required argument: y'
+          ])
+          r.logs.should.have.length(0)
+          r.exit.should.be.ok
+        })
+        it('fails if one command and an argument not on the list are provided', function () {
+          var r = checkUsage(function () {
+            return yargs('wombat -w 10 -y 10')
+              .usage('Usage: $0 -w NUM -m NUM')
+              .required(1, ['w', 'm'])
+              .strict()
+              .wrap(null)
+              .argv
+          })
+          r.result.should.have.property('w', 10)
+          r.result.should.have.property('y', 10)
+          r.result.should.have.property('_').with.length(1)
+          r.errors.join('\n').split(/\n+/).should.deep.equal([
+            'Usage: ./usage -w NUM -m NUM',
+            'Options:',
+            '  -w  [required]',
+            '  -m  [required]',
+            'Missing required argument: m'
           ])
           r.logs.should.have.length(0)
           r.exit.should.be.ok

--- a/test/usage.js
+++ b/test/usage.js
@@ -36,7 +36,7 @@ describe('usage tests', function () {
         r.exit.should.be.ok
       })
 
-      it('fails if one command and an argument not on the list are provided', function () {
+      it('missing argument message given if one command, but an argument not on the list is provided', function () {
         var r = checkUsage(function () {
           return yargs('wombat -w 10 -y 10')
             .usage('Usage: $0 -w NUM -m NUM')
@@ -57,6 +57,49 @@ describe('usage tests', function () {
         ])
         r.logs.should.have.length(0)
         r.exit.should.be.ok
+      })
+
+      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
+        var r = checkUsage(function () {
+          return yargs('-w 10 -y 10')
+            .usage('Usage: $0 -w NUM -m NUM')
+            .demand(1, ['w', 'm'])
+            .strict()
+            .wrap(null)
+            .argv
+        })
+        r.result.should.have.property('w', 10)
+        r.result.should.have.property('y', 10)
+        r.result.should.have.property('_').with.length(0)
+        r.errors.join('\n').split(/\n+/).should.deep.equal([
+          'Usage: ./usage -w NUM -m NUM',
+          'Options:',
+          '  -w  [required]',
+          '  -m  [required]',
+          'Not enough non-option arguments: got 0, need at least 1'
+        ])
+        r.logs.should.have.length(0)
+        r.exit.should.be.ok
+      })
+
+      it('no failure occurs if the required arguments and the required number of commands are provided.', function () {
+        var r = checkUsage(function () {
+          return yargs('wombat -w 10 -m 10')
+            .usage('Usage: $0 -w NUM -m NUM')
+            .command('wombat', 'wombat handlers', function (yargs, argv) {
+              return argv
+            })
+            .demand(1, ['w', 'm'])
+            .strict()
+            .wrap(null)
+            .argv
+        })
+        r.result.should.have.property('w', 10)
+        r.result.should.have.property('m', 10)
+        r.result.should.have.property('_').with.length(1)
+        r.should.have.property('errors').with.length(0)
+        r.should.have.property('logs').with.length(0)
+        r.should.have.property('exit', false)
       })
 
       describe('using .require()', function () {
@@ -81,7 +124,7 @@ describe('usage tests', function () {
           r.logs.should.have.length(0)
           r.exit.should.be.ok
         })
-        it('fails if one command and an argument not on the list are provided', function () {
+        it('missing argument message given if one command and an argument not on the list are provided', function () {
           var r = checkUsage(function () {
             return yargs('wombat -w 10 -y 10')
               .usage('Usage: $0 -w NUM -m NUM')
@@ -103,6 +146,49 @@ describe('usage tests', function () {
           r.logs.should.have.length(0)
           r.exit.should.be.ok
         })
+      })
+
+      it('missing command message if all the required arguments exist, but not enough commands are provided', function () {
+        var r = checkUsage(function () {
+          return yargs('-w 10 -y 10')
+            .usage('Usage: $0 -w NUM -m NUM')
+            .require(1, ['w', 'm'])
+            .strict()
+            .wrap(null)
+            .argv
+        })
+        r.result.should.have.property('w', 10)
+        r.result.should.have.property('y', 10)
+        r.result.should.have.property('_').with.length(0)
+        r.errors.join('\n').split(/\n+/).should.deep.equal([
+          'Usage: ./usage -w NUM -m NUM',
+          'Options:',
+          '  -w  [required]',
+          '  -m  [required]',
+          'Not enough non-option arguments: got 0, need at least 1'
+        ])
+        r.logs.should.have.length(0)
+        r.exit.should.be.ok
+      })
+
+      it('no failure occurs if the required arguments and the required number of commands are provided.', function () {
+        var r = checkUsage(function () {
+          return yargs('wombat -w 10 -m 10')
+            .usage('Usage: $0 -w NUM -m NUM')
+            .command('wombat', 'wombat handlers', function (yargs, argv) {
+              return argv
+            })
+            .require(1, ['w', 'm'])
+            .strict()
+            .wrap(null)
+            .argv
+        })
+        r.result.should.have.property('w', 10)
+        r.result.should.have.property('m', 10)
+        r.result.should.have.property('_').with.length(1)
+        r.should.have.property('errors').with.length(0)
+        r.should.have.property('logs').with.length(0)
+        r.should.have.property('exit', false)
       })
     })
 

--- a/test/validation.js
+++ b/test/validation.js
@@ -87,6 +87,26 @@ describe('validation tests', function () {
         .argv
     })
 
+    it('fails when a required argument is missing', function (done) {
+      yargs('-w 10 marsupial')
+        .demand(1, ['w', 'b'])
+        .fail(function (msg) {
+          msg.should.equal('Missing required argument: b')
+          return done()
+        })
+        .argv
+    })
+
+    it('fails when required arguments are present, but a command is missing', function (done) {
+      yargs('-w 10 -m wombat')
+        .demand(1, ['w', 'm'])
+        .fail(function (msg) {
+          msg.should.equal('Not enough non-option arguments: got 0, need at least 1')
+          return done()
+        })
+        .argv
+    })
+
     it('fails without a message if msg is null', function (done) {
       yargs([])
         .demand(1, null)

--- a/test/validation.js
+++ b/test/validation.js
@@ -87,20 +87,6 @@ describe('validation tests', function () {
         .argv
     })
 
-    it('fails with one command and an argument not on the list are provided', function (done) {
-      yargs(['wombat --mob'])
-        .command('wombat', 'wombat handlers', function (yargs, argv) {
-          return argv
-        })
-        .demand(1, ['wisdom', 'marsupial'])
-        .strict()
-        .fail(function (msg) {
-          msg.should.equal('Uknown argument: mob')
-          return done()
-        })
-        .argv
-    })
-
     it('fails without a message if msg is null', function (done) {
       yargs([])
         .demand(1, null)

--- a/test/validation.js
+++ b/test/validation.js
@@ -72,7 +72,12 @@ describe('validation tests', function () {
 
     it('fails with invalid command', function (done) {
       yargs(['koala'])
-        .command('wombat', 'wombat handlers', function () {})
+        .command('wombat', 'wombat burrows', function (yargs, argv) {
+          return argv
+        })
+        .command('kangaroo', 'kangaroo handlers', function (yargs, argv) {
+          return argv
+        })
         .demand(1)
         .strict()
         .fail(function (msg) {

--- a/test/validation.js
+++ b/test/validation.js
@@ -70,6 +70,18 @@ describe('validation tests', function () {
         .argv
     })
 
+    it('fails with invalid command', function (done) {
+      yargs(['koala'])
+        .command('wombat', 'wombat handlers', function () {})
+        .demand(1)
+        .strict()
+        .fail(function (msg) {
+          msg.should.equal('Unknown argument: koala')
+          return done()
+        })
+        .argv
+    })
+
     it('fails without a message if msg is null', function (done) {
       yargs([])
         .demand(1, null)

--- a/test/validation.js
+++ b/test/validation.js
@@ -87,6 +87,20 @@ describe('validation tests', function () {
         .argv
     })
 
+    it('fails with one command and an argument not on the list are provided', function (done) {
+      yargs(['wombat --mob'])
+        .command('wombat', 'wombat handlers', function (yargs, argv) {
+          return argv
+        })
+        .demand(1, ['wisdom', 'marsupial'])
+        .strict()
+        .fail(function (msg) {
+          msg.should.equal('Uknown argument: mob')
+          return done()
+        })
+        .argv
+    })
+
     it('fails without a message if msg is null', function (done) {
       yargs([])
         .demand(1, null)


### PR DESCRIPTION
Check if `argv` provided is in `commandHandlers` if using `.strict()`.

A WIP pull for #174 