### PR TITLE
Made help() only assign '--help' option if called without args

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ when displaying usage instructions, e.g.,
 
 ```js
 var yargs = require('yargs')(['--help'])
-  .help('help')
+  .help()
   .group('batman', 'Heroes:')
   .describe('batman', "world's greatest detective")
   .wrap(null)
@@ -753,14 +753,15 @@ Add an option (e.g. `--help`) that displays the usage string and exits the
 process. If present, the `description` parameter customizes the description of
 the help option in the usage string.
 
-If invoked without parameters, `.help()` returns the generated usage string.
+If invoked without parameters, `.help()` will make `--help` the option to trigger
+help output.
 
 Example:
 
 ```js
-var yargs = require("yargs")
+var yargs = require("yargs")['--help']
   .usage("$0 -operand1 number -operand2 number -operation [add|subtract]");
-console.log(yargs.help());
+  .help()
 ```
 
 Later on, `argv` can be retrieved with `yargs.argv`.

--- a/index.js
+++ b/index.js
@@ -393,7 +393,8 @@ function Argv (processArgs, cwd) {
   }
 
   var helpOpt = null
-  self.addHelpOpt = function (opt, msg) {
+  self.addHelpOpt = self.help = function (opt, msg) {
+    opt = opt || 'help'
     helpOpt = opt
     self.boolean(opt)
     self.describe(opt, msg || usage.deferY18nLookup('Show help'))
@@ -415,14 +416,6 @@ function Argv (processArgs, cwd) {
   }
   self.getExitProcess = function () {
     return exitProcess
-  }
-
-  self.help = function () {
-    if (arguments.length > 0) return self.addHelpOpt.apply(self, arguments)
-
-    if (!self.parsed) parseArgs(processArgs) // run parser, if it has not already been executed.
-
-    return self.addHelpOpt.apply(self, 'help')
   }
 
   var completionCommand = null

--- a/index.js
+++ b/index.js
@@ -422,7 +422,7 @@ function Argv (processArgs, cwd) {
 
     if (!self.parsed) parseArgs(processArgs) // run parser, if it has not already been executed.
 
-    return usage.help()
+    return self.addHelpOpt.apply(self, 'help')
   }
 
   var completionCommand = null

--- a/test/usage.js
+++ b/test/usage.js
@@ -997,13 +997,22 @@ describe('usage tests', function () {
     yargs.rebase(['home', 'chevex', 'foo'].join(path.sep), ['home', 'chevex', 'pow', 'zoom.txt'].join(path.sep)).should.equal(['..', 'pow', 'zoom.txt'].join(path.sep))
   })
 
-  // Fixes: https://github.com/chevex/yargs/issues/71
-  it('should not raise an exception if help called on empty arguments', function () {
+  it('should not print usage string if help() is called without arguments', function () {
     var r = checkUsage(function () {
       return yargs([]).usage('foo').help()
     })
 
-    r.result.should.match(/foo/)
+    console.log(r)
+    r.result.should.equal(undefined)
+  })
+
+  it('should add --help as an option for printing usage text if help() is called without arguments', function () {
+    var r = checkUsage(function () {
+      return yargs(['--help']).usage('foo').help()
+    })
+
+    console.log(r)
+    r.result.should.equal(/foo/)
   })
 
   describe('wrap', function () {

--- a/test/usage.js
+++ b/test/usage.js
@@ -999,20 +999,18 @@ describe('usage tests', function () {
 
   it('should not print usage string if help() is called without arguments', function () {
     var r = checkUsage(function () {
-      return yargs([]).usage('foo').help()
+      return yargs([]).usage('foo').help().argv
     })
 
-    console.log(r)
-    r.result.should.equal(undefined)
+    r.logs.length.should.equal(0)
   })
 
   it('should add --help as an option for printing usage text if help() is called without arguments', function () {
     var r = checkUsage(function () {
-      return yargs(['--help']).usage('foo').help()
+      return yargs(['--help']).usage('foo').help().argv
     })
 
-    console.log(r)
-    r.result.should.equal(/foo/)
+    r.logs.length.should.not.equal(0)
   })
 
   describe('wrap', function () {


### PR DESCRIPTION
This takes care of @bcoe's idea in #367