### PR TITLE
introduces pkgConf feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 4.x
 
+- [#378](https://github.com/bcoe/yargs/pull/378) introduces the pkgConf feature, which tells
+  yargs to load default argument values from a key on a project's package.json (@bcoe)
 - [#376](https://github.com/bcoe/yargs/pull/376) **breaking change**, make help() method signature
    more consistent with other commands (@maxrimue)
 - [#368](https://github.com/bcoe/yargs/pull/368) **breaking change**, overhaul to command handling API:

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,12 @@ Parse `args` instead of `process.argv`. Returns the `argv` object.
 
 `args` may either be a pre-processed argv array, or a raw argument string.
 
+.pkgConf(key)
+------------
+
+Similar to [`config()`](#config), indicates that yargs should read
+default argument values from the specified key in package.json.
+
 .require(key, [msg | boolean])
 ------------------------------
 .required(key, [msg | boolean])

--- a/README.md
+++ b/README.md
@@ -1077,11 +1077,14 @@ Parse `args` instead of `process.argv`. Returns the `argv` object.
 
 `args` may either be a pre-processed argv array, or a raw argument string.
 
-.pkgConf(key)
+.pkgConf(key, [cwd])
 ------------
 
 Similar to [`config()`](#config), indicates that yargs should read
 default argument values from the specified key in package.json.
+
+`cwd` can optionally be provided, the package.json will be read
+from this location.
 
 .require(key, [msg | boolean])
 ------------------------------

--- a/index.js
+++ b/index.js
@@ -295,6 +295,23 @@ function Argv (processArgs, cwd) {
     return self
   }
 
+  self.pkgConf = function (key) {
+    var conf = null
+
+    var obj = readPkgUp.sync({
+      cwd: requireMainFilename()
+    })
+
+    if (obj.pkg && obj.pkg[key] && typeof obj.pkg[key] === 'object') {
+      conf = obj.pkg[key]
+      Object.keys(conf).forEach(function (k) {
+        self.default(k, conf[k])
+      })
+    }
+
+    return self
+  }
+
   self.parse = function (args) {
     return parseArgs(args)
   }

--- a/index.js
+++ b/index.js
@@ -295,11 +295,11 @@ function Argv (processArgs, cwd) {
     return self
   }
 
-  self.pkgConf = function (key) {
+  self.pkgConf = function (key, path) {
     var conf = null
 
     var obj = readPkgUp.sync({
-      cwd: requireMainFilename()
+      cwd: path || requireMainFilename()
     })
 
     if (obj.pkg && obj.pkg[key] && typeof obj.pkg[key] === 'object') {

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -836,5 +836,14 @@ describe('yargs dsl tests', function () {
       argv.foo.should.equal('a')
       expect(argv.git).to.equal(undefined)
     })
+
+    it('allows an alternative cwd to be specified', function () {
+      var argv = yargs('--foo a')
+        .pkgConf('yargs', './test/fixtures')
+        .argv
+
+      argv.foo.should.equal('a')
+      argv.dotNotation.should.equal(false)
+    })
   })
 })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -806,4 +806,35 @@ describe('yargs dsl tests', function () {
       expect(options.key.bar).to.equal(undefined)
     })
   })
+
+  describe('pkgConf', function () {
+    it('uses values from package.json as defaults', function () {
+      var argv = yargs('--foo a').pkgConf('repository').argv
+
+      argv.foo.should.equal('a')
+      argv.type.should.equal('git')
+    })
+
+    it('combines yargs defaults with package.json defaults', function () {
+      var argv = yargs('--foo a')
+        .default('b', 99)
+        .pkgConf('repository')
+        .argv
+
+      argv.b.should.equal(99)
+      argv.foo.should.equal('a')
+      argv.type.should.equal('git')
+    })
+
+    it('is cool with a key not existing', function () {
+      var argv = yargs('--foo a')
+        .default('b', 99)
+        .pkgConf('banana')
+        .argv
+
+      argv.b.should.equal(99)
+      argv.foo.should.equal('a')
+      expect(argv.git).to.equal(undefined)
+    })
+  })
 })


### PR DESCRIPTION
You can now call `yargs.pkgConf('configKey')` which will tell yargs to load defaults from a key in your package.json, snazzy!
