### PR TITLE
[WIP] add number type usage from yargs-parser PR #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ Valid `opt` keys include:
 - `nargs`: number, specify how many arguments should be consumed for the option, see [`nargs()`](#nargs)
 - `requiresArg`: boolean, require the option be specified with a value, see [`requiresArg()`](#requiresArg)
 - `string`: boolean, interpret option as a string, see [`string()`](#string)
+- `number`: number, keys are treated as numbers, [`number()`](#number)
 - `type`: one of the following strings
     - `'array'`: synonymous for `array: true`, see [`array()`](#array)
     - `'boolean'`: synonymous for `boolean: true`, see [`boolean()`](#boolean)
@@ -1079,6 +1080,20 @@ If `key` is an array, interpret all the elements as strings.
 
 `.string('_')` will result in non-hyphenated arguments being interpreted as strings,
 regardless of whether they resemble numbers.
+
+<a name="number"></a>.number([key])
+------------
+Specify options with a numeric argument.
+
+If an argument is not provided with the option, will return `undefined`.
+
+If a non-numeric argument is provided, will return a `NaN`.
+
+```js
+var argv = require('yargs')
+  .number(['n'])
+  .argv
+```
 
 .updateLocale(obj)
 ------------------

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function Argv (processArgs, cwd) {
       requiresArg: [],
       count: [],
       normalize: [],
+      number: [],
       config: {},
       envPrefix: undefined
     }
@@ -99,6 +100,11 @@ function Argv (processArgs, cwd) {
     } else {
       options.narg[key] = n
     }
+    return self
+  }
+
+  self.number = function (numbers) {
+    options.numbers.push.apply(options.number, [].concat(numbers))
     return self
   }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -199,6 +199,7 @@ module.exports = function (yargs, y18n) {
         if (~options.string.indexOf(key)) type = '[' + __('string') + ']'
         if (~options.normalize.indexOf(key)) type = '[' + __('string') + ']'
         if (~options.array.indexOf(key)) type = '[' + __('array') + ']'
+        if (~options.number.indexOf(key)) type = '[' + __('number') + ']'
 
         var extra = [
           type,
@@ -289,6 +290,7 @@ module.exports = function (yargs, y18n) {
         if (~options.string.indexOf(alias)) yargs.string(key)
         if (~options.normalize.indexOf(alias)) yargs.normalize(key)
         if (~options.array.indexOf(alias)) yargs.array(key)
+        if (~options.number.indexOf(alias)) yargs.number(key)
       })
     })
   }

--- a/test/usage.js
+++ b/test/usage.js
@@ -1326,6 +1326,26 @@ describe('usage tests', function () {
     })
   })
 
+  describe('number', function () {
+    it("should display 'type' number in help message", function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .number(['n'])
+          .describe('n', 'number of cherries')
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  -h         Show help  [boolean]',
+        '  -n number of cherries [number]',
+        ''
+      ])
+    })
+  })
+
   describe('defaultDescription', function () {
     describe('using option() without default()', function () {
       it('should output given desc with default value', function () {
@@ -1484,6 +1504,26 @@ describe('usage tests', function () {
         'Options:',
         '  -h         Show help  [boolean]',
         '  -f, --foo  bar  [string]',
+        ''
+      ])
+    })
+
+    it("should display 'type' number in help message if set for alias", function () {
+      var r = checkUsage(function () {
+        return yargs(['-h'])
+          .string('foo')
+          .describe('foo', 'bar')
+          .alias('f', 'foo')
+          .number(['n'])
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs.join('\n').split(/\n+/).should.deep.equal([
+        'Options:',
+        '  -h         Show help  [boolean]',
+        '  -f, --foo  bar  [number]',
         ''
       ])
     })

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -232,6 +232,7 @@ describe('yargs dsl tests', function () {
         requiresArg: [],
         count: [],
         normalize: [],
+        number: [],
         config: {},
         envPrefix: undefined
       }


### PR DESCRIPTION
(third time is a charm :nail_care:)

This PR requires the following before merging: 
- [x] edit usage tests
- [x] merge [new number type](https://github.com/yargs/yargs-parser/pull/7) PR
- [x] update yargs-parser version in [4.x branch](https://github.com/bcoe/yargs/tree/4.x)
- [x] update docs
- [ ] update changelog in #377 