### PR TITLE
Pass the original error as the second argument of fail() handler. (fixes #373)

### DIFF
--- a/index.js
+++ b/index.js
@@ -535,7 +535,7 @@ function Argv (processArgs, cwd) {
       try {
         args = parseArgs(processArgs)
       } catch (err) {
-        usage.fail(err.message)
+        usage.fail(err.message, err)
       }
 
       return args

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -31,10 +31,10 @@ module.exports = function (yargs, y18n) {
   }
 
   var failureOutput = false
-  self.fail = function (msg) {
+  self.fail = function (msg, err) {
     if (fails.length) {
       fails.forEach(function (f) {
-        f(msg)
+        f(msg, err)
       })
     } else {
       // don't output failure message more than once
@@ -50,7 +50,7 @@ module.exports = function (yargs, y18n) {
       if (yargs.getExitProcess()) {
         process.exit(1)
       } else {
-        throw new Error(msg)
+        throw err || new Error(msg)
       }
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -192,7 +192,7 @@ module.exports = function (yargs, usage, y18n) {
           usage.fail(result)
         }
       } catch (err) {
-        usage.fail(err.message ? err.message : err)
+        usage.fail(err.message ? err.message : err, err)
       }
     })
   }


### PR DESCRIPTION
A follow up to https://github.com/bcoe/yargs/pull/374