### PR TITLE
Do not include module commands in usage text more than once

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -6,14 +6,14 @@ module.exports = function (yargs, usage, validation) {
 
   var handlers = {}
   self.addHandler = function (cmd, description, builder, handler) {
-    if (description !== false) {
-      usage.command(cmd, description)
-    }
-
     // allow a module to be provided for a command.
     if (typeof builder === 'object' && builder.builder && typeof builder.handler === 'function') {
       self.addHandler(cmd, description, builder.builder, builder.handler)
       return
+    }
+
+    if (description !== false) {
+      usage.command(cmd, description)
     }
 
     // we should not register a handler if no

--- a/test/usage.js
+++ b/test/usage.js
@@ -1449,6 +1449,29 @@ describe('usage tests', function () {
         ''
       ])
     })
+
+    it('should list a module command only once', function () {
+      var r = checkUsage(function () {
+        return yargs('--help')
+          .command('upload', 'upload something', {
+            builder: function (yargs) {
+              return yargs
+            },
+            handler: function (argv) {}
+          })
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  upload  upload something',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
   })
 
   describe('epilogue', function () {


### PR DESCRIPTION
Just need to check for module command _before_ adding it to usage; otherwise the recursion adds it twice. Includes test to guard against regression.