### PR TITLE
Do not reset wrap for commands

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -383,6 +383,7 @@ module.exports = function (yargs, y18n) {
   }
 
   self.reset = function (globalLookup) {
+    // do not reset wrap here
     fails = []
     failMessage = null
     failureOutput = false
@@ -390,7 +391,6 @@ module.exports = function (yargs, y18n) {
     epilog = undefined
     examples = []
     commands = []
-    wrap = windowWidth()
     descriptions = objFilter(descriptions, function (k, v) {
       return globalLookup[k]
     })

--- a/test/usage.js
+++ b/test/usage.js
@@ -1423,6 +1423,98 @@ describe('usage tests', function () {
       ])
     })
 
+    it('preserves global wrap() for commands that do not override it', function () {
+      var uploadCommand = 'upload <dest>'
+      var uploadDesc = 'Upload cwd to remote destination'
+      var uploadOpts = {
+        force: {
+          describe: 'Force overwrite of remote directory contents',
+          type: 'boolean'
+        }
+      }
+      var uploadHandler = function (argv) {}
+
+      var generalHelp = checkUsage(function () {
+        return yargs('--help')
+          .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
+          .help()
+          .wrap(null)
+          .argv
+      })
+      var commandHelp = checkUsage(function () {
+        return yargs('upload --help')
+          .command(uploadCommand, uploadDesc, uploadOpts, uploadHandler)
+          .help()
+          .wrap(null)
+          .argv
+      })
+
+      generalHelp.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  upload <dest>  Upload cwd to remote destination',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+      commandHelp.logs[0].split('\n').should.deep.equal([
+        './usage upload <dest>',
+        '',
+        'Options:',
+        '  --help   Show help  [boolean]',
+        '  --force  Force overwrite of remote directory contents  [boolean]',
+        ''
+      ])
+    })
+
+    it('allows a command to override global wrap()', function () {
+      var uploadCommand = 'upload <dest>'
+      var uploadDesc = 'Upload cwd to remote destination'
+      var uploadBuilder = function (yargs) {
+        return yargs
+          .usage('$0 ' + uploadCommand)
+          .option('force', {
+            describe: 'Force overwrite of remote directory contents',
+            type: 'boolean'
+          })
+          .wrap(46)
+      }
+      var uploadHandler = function (argv) {}
+
+      var generalHelp = checkUsage(function () {
+        return yargs('--help')
+          .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
+          .help()
+          .wrap(null)
+          .argv
+      })
+      var commandHelp = checkUsage(function () {
+        return yargs('upload --help')
+          .command(uploadCommand, uploadDesc, uploadBuilder, uploadHandler)
+          .help()
+          .wrap(null)
+          .argv
+      })
+
+      generalHelp.logs[0].split('\n').should.deep.equal([
+        'Commands:',
+        '  upload <dest>  Upload cwd to remote destination',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+      commandHelp.logs[0].split('\n').should.deep.equal([
+        './usage upload <dest>',
+        '',
+        'Options:',
+        '  --help   Show help                 [boolean]',
+        '  --force  Force overwrite of remote directory',
+        '           contents                  [boolean]',
+        ''
+      ])
+    })
+
     it('resets groups for a command handler, respecting order', function () {
       var r = checkUsage(function () {
         return yargs(['upload', '-h'])


### PR DESCRIPTION
Preserve the "global" `wrap()` value so that usage width is consistent for commands that do not wish to override it (particularly when using an options object instead of a builder function). Commands that wish to override it may still do so.

Includes a test for each scenario.