### PR TITLE
Use implicit usage string when not set by command builder function

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -60,6 +60,13 @@ module.exports = function (yargs, usage, validation) {
       // a function can be provided, which interacts which builds
       // up a yargs chain and returns it.
       innerArgv = commandHandler.builder(yargs.reset(parsed.aliases))
+      // if the builder function did not yet parse argv with reset yargs
+      // and did not explicitly set a usage() string, then apply the
+      // original command string as usage() for consistent behavior with
+      // options object below
+      if (yargs.parsed === false && typeof yargs.getUsageInstance().getUsage() === 'undefined') {
+        yargs.usage('$0 ' + commandHandler.original)
+      }
       innerArgv = innerArgv ? innerArgv.argv : argv
     } else if (commandHandler.builder && typeof commandHandler.builder === 'object') {
       // as a short hand, an object can instead be provided, specifying

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -60,6 +60,9 @@ module.exports = function (yargs, y18n) {
   self.usage = function (msg) {
     usage = msg
   }
+  self.getUsage = function () {
+    return usage
+  }
 
   var examples = []
   self.example = function (cmd, description) {

--- a/test/usage.js
+++ b/test/usage.js
@@ -1472,7 +1472,6 @@ describe('usage tests', function () {
       var uploadDesc = 'Upload cwd to remote destination'
       var uploadBuilder = function (yargs) {
         return yargs
-          .usage('$0 ' + uploadCommand)
           .option('force', {
             describe: 'Force overwrite of remote directory contents',
             type: 'boolean'
@@ -1533,6 +1532,8 @@ describe('usage tests', function () {
       })
 
       r.logs[0].split('\n').should.deep.equal([
+        './usage upload',
+        '',
         'Flags:',
         '  -q  [boolean]',
         '',
@@ -1559,6 +1560,45 @@ describe('usage tests', function () {
         'Commands:',
         '  upload  upload something',
         '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('allows a builder function to override default usage() string', function () {
+      var r = checkUsage(function () {
+        return yargs('upload --help')
+          .command('upload', 'upload something', {
+            builder: function (yargs) {
+              return yargs.usage('Usage: program upload <something> [opts]').demand(1)
+            },
+            handler: function (argv) {}
+          })
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Usage: program upload <something> [opts]',
+        '',
+        'Options:',
+        '  --help  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('allows a builder function to disable default usage() with null', function () {
+      var r = checkUsage(function () {
+        return yargs('upload --help')
+          .command('upload', 'upload something', function (yargs) {
+            return yargs.usage(null)
+          }, function (argv) {})
+          .help().wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
         'Options:',
         '  --help  Show help  [boolean]',
         ''

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -290,6 +290,8 @@ describe('yargs dsl tests', function () {
       })
 
       r.logs[0].split('\n').should.deep.equal([
+        './usage blerg',
+        '',
         'Commands:',
         '  snuh  snuh command',
         '',


### PR DESCRIPTION
I like the feature of using the original command string as the `usage()` string for commands that pass an options object instead of a builder function.

I thought it'd be cool to give commands with builder functions the same treatment as long as they don't:

1. parse argv in the builder function itself (in which case a `--help` flag would have already triggered usage output)
2. explicitly set the `usage()` string in the builder function

This is totally subjective and so is up for debate, but I think keeping the different command approaches as similar as possible is a good idea that could lead to more interesting features down the road (e.g. command suggestions, etc).

Also not sure if this "breaks" user expectations based on 3.x functionality, but hey, this is 4.x.