### PR TITLE
Preserve groups containing global keys

### DIFF
--- a/test/usage.js
+++ b/test/usage.js
@@ -1542,6 +1542,117 @@ describe('usage tests', function () {
       ])
     })
 
+    it('preserves groups with global keys', function () {
+      var r = checkUsage(function () {
+        return yargs(['upload', '-h'])
+          .command('upload', 'upload something', function (yargs) {
+            return yargs
+              .option('q', {
+                type: 'boolean',
+                group: 'Flags:'
+              })
+              .wrap(null)
+          })
+          .option('i', {
+            type: 'boolean',
+            global: true,
+            group: 'Awesome Flags:'
+          })
+          .option('j', {
+            type: 'boolean',
+            global: false, // not global so not preserved, even though the group is
+            group: 'Awesome Flags:'
+          })
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Flags:',
+        '  -q  [boolean]',
+        '',
+        'Awesome Flags:',
+        '  -i  [boolean]',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('can add to preserved groups', function () {
+      var r = checkUsage(function () {
+        return yargs(['upload', '-h'])
+          .command('upload', 'upload something', function (yargs) {
+            return yargs
+              .option('q', {
+                type: 'boolean',
+                group: 'Awesome Flags:'
+              })
+              .wrap(null)
+          })
+          .option('i', {
+            type: 'boolean',
+            global: true,
+            group: 'Awesome Flags:'
+          })
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Awesome Flags:',
+        '  -i  [boolean]',
+        '  -q  [boolean]',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
+    it('can bump up preserved groups', function () {
+      var r = checkUsage(function () {
+        return yargs(['upload', '-h'])
+          .command('upload', 'upload something', function (yargs) {
+            return yargs
+              .group([], 'Awesome Flags:')
+              .option('q', {
+                type: 'boolean',
+                group: 'Flags:'
+              })
+              .wrap(null)
+          })
+          .option('i', {
+            type: 'boolean',
+            global: true,
+            group: 'Awesome Flags:'
+          })
+          .option('j', {
+            type: 'boolean',
+            global: false, // not global so not preserved, even though the group is
+            group: 'Awesome Flags:'
+          })
+          .help('h')
+          .wrap(null)
+          .argv
+      })
+
+      r.logs[0].split('\n').should.deep.equal([
+        'Awesome Flags:',
+        '  -i  [boolean]',
+        '',
+        'Flags:',
+        '  -q  [boolean]',
+        '',
+        'Options:',
+        '  -h  Show help  [boolean]',
+        ''
+      ])
+    })
+
     it('should list a module command only once', function () {
       var r = checkUsage(function () {
         return yargs('--help')


### PR DESCRIPTION
Heya! I used yargs in a new CLI tool the other day. This tool takes some global options as well as per-command options. I noticed I had to [restore the global option groups](https://github.com/novemberborn/wilee/blob/cdf47828ae17dd9ffd3944def85adf189205f403/src/lib/cli.js#L45) for each command, which I was not expecting.

With this PR I'm proposing that groups containing global keys are preserved within commands. Please let me know if that's a sensible thing for yargs to do!

One concern raised in #336 is the ability to control the order of the groups in each command's help output. Currently this PR puts the groups with global keys first. Possibly the `groups` object could be reordered if the group is redeclared without keys.

I also may be misunderstanding the myriad uses of `yargs.reset()`, though the tests seem to pass aside for one introduced to fix #336. I can fix those tests if people are happy with this approach.

Thanks.